### PR TITLE
fix(after-hours): LRU eviction for the per-chat cooldown map (v0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository provides:
 <!-- BEGIN PLUGIN CATALOG -->
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
-| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.1.1 | stable |
+| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.1.2 | stable |
 | [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.2 | stable |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.1 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.2 | stable |

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,14 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-06-23
+
+### Changed
+
+- The per-chat cooldown map now evicts least-recently-used entries (re-inserting a chat on each reply)
+  instead of first-seen order, so a continuously-active chat keeps its cooldown when the map reaches its
+  cap rather than being evicted and allowed to bypass the throttle.
+
 ## [0.1.1] — 2026-06-23
 
 ### Added

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -12,7 +12,7 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `after-hours` |
-| **Version** | 0.1.1 |
+| **Version** | 0.1.2 |
 | **Released** | 2026-06-23 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |

--- a/after-hours/index.test.ts
+++ b/after-hours/index.test.ts
@@ -44,3 +44,13 @@ test('allowReply enforces the per-chat cooldown and caps the map', () => {
   assert.equal(big.size, 5000);
   assert.equal(big.has('k-0'), false);
 });
+
+test('allowReply eviction is recency-aware: re-touching a key protects it', () => {
+  const map = new Map<string, number>();
+  for (let i = 0; i < 5000; i++) allowReply(map, `k-${i}`, i, 0);
+  allowReply(map, 'k-0', 10000, 0); // re-touch -> most recently used
+  allowReply(map, 'k-new', 10001, 0); // overflow -> evict genuinely-oldest
+  assert.equal(map.size, 5000);
+  assert.equal(map.has('k-0'), true); // protected by recent touch
+  assert.equal(map.has('k-1'), false); // now the oldest, evicted
+});

--- a/after-hours/index.ts
+++ b/after-hours/index.ts
@@ -41,12 +41,13 @@ export function parseConfig(raw: Record<string, unknown>): { config: AfterHoursC
 }
 
 /**
- * Decide whether an after-hours reply may go to `key` now. On allow, records `nowMs` and caps the map
- * (drop oldest). `cooldownMs` of 0 always allows.
+ * Decide whether an after-hours reply may go to `key` now. On allow, records `nowMs` (re-inserting so
+ * the map evicts least-recently-used) and caps the map by dropping the LRU entry. `cooldownMs` of 0 always allows.
  */
 export function allowReply(map: Map<string, number>, key: string, nowMs: number, cooldownMs: number): boolean {
   const last = map.get(key);
   if (last !== undefined && nowMs - last < cooldownMs) return false;
+  map.delete(key); // re-insert so iteration order tracks recency (LRU by touch)
   map.set(key, nowMs);
   if (map.size > MAX_COOLDOWN_ENTRIES) {
     const oldest = map.keys().next().value as string | undefined;

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "after-hours",
   "name": "After-Hours Auto-Reply",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "after-hours",
     "name": "After-Hours Auto-Reply",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -22,7 +22,7 @@
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.1.1/after-hours.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.1.2/after-hours.zip",
     "i18n": {
       "es": {
         "name": "Respuesta Automática Fuera de Horario",


### PR DESCRIPTION
## Summary

Hardens the per-chat cooldown in **after-hours**, released as **v0.1.2**.

The cooldown map capped at 5000 entries and evicted in first-insertion order. Re-setting an existing chat's timestamp didn't refresh its position, so a continuously-active chat kept its original (oldest) slot and was evicted first once the cap was reached. After eviction, its next message saw no record and was allowed immediately — bypassing the configured cooldown / amplifying replies.

`allowReply` now deletes-then-sets the key on each touch, so iteration order tracks recency and `keys().next().value` is the genuinely least-recently-used entry. Only idle chats are dropped; an in-cooldown chat is never refreshed.

## Tests
- New: re-touching a key protects it from eviction; the genuinely-oldest entry is dropped.
- Existing cap/cooldown tests still pass. `tsc --noEmit` clean, bundle packages cleanly.