### PR TITLE
fix(faq-bot): reject nested unbounded quantifiers hidden behind wrapping groups (v0.1.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository provides:
 | ------ | ----------- | ------- | ------ |
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.1.2 | stable |
 | [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.3 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.2 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.3 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.3 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.2.2 | stable |
 <!-- END PLUGIN CATALOG -->

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,15 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.1.3] — 2026-06-23
+
+### Fixed
+
+- The regex safety check now also rejects a nested unbounded quantifier hidden behind one or more
+  wrapping groups (e.g. `((a+))+`, `(((a+)))*`). The previous check only inspected a group that was
+  directly quantified, so an extra layer of parentheses could slip a catastrophic pattern through.
+  Patterns that carry only a single quantifier (e.g. `((ab)+)`) are still accepted.
+
 ## [0.1.2] — 2026-06-23
 
 ### Changed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -13,7 +13,7 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.1.2 |
+| **Version** | 0.1.3 |
 | **Released** | 2026-06-23 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -43,6 +43,31 @@ test('parseRules skips a catastrophic-backtracking regex (nested unbounded quant
   assert.deepEqual(skipped, ['(a+)+$', '(\\w+\\s?)*$']);
 });
 
+test('parseRules rejects nested unbounded quantifiers hidden behind extra groups', () => {
+  const { rules, skipped } = parseRules(
+    JSON.stringify([
+      { mode: 'regex', pattern: '((a+))+$', reply: 'evil' },
+      { mode: 'regex', pattern: '(((a+)))*', reply: 'evil2' },
+      { mode: 'regex', pattern: '((\\w+\\s?))*$', reply: 'evil3' },
+      { mode: 'contains', pattern: 'hi', reply: 'hello' },
+    ]),
+  );
+  assert.equal(rules.length, 1);
+  assert.deepEqual(skipped, ['((a+))+$', '(((a+)))*', '((\\w+\\s?))*$']);
+});
+
+test('parseRules keeps grouped patterns that carry only a single quantifier', () => {
+  const { rules, skipped } = parseRules(
+    JSON.stringify([
+      { mode: 'regex', pattern: '((ab)+)', reply: 'a' },
+      { mode: 'regex', pattern: '(a+)', reply: 'b' },
+      { mode: 'regex', pattern: '((cat|dog))', reply: 'c' },
+    ]),
+  );
+  assert.equal(skipped.length, 0);
+  assert.equal(rules.length, 3);
+});
+
 test('parseRules keeps safe regexes (single/non-nested quantifiers, lookahead)', () => {
   const { rules, skipped } = parseRules(
     JSON.stringify([

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -51,6 +51,10 @@ export function isSafeRegexPattern(p: string): boolean {
         if (group.hasUnbounded) return false; // nested unbounded quantifier -> catastrophic
         if (stack.length) stack[stack.length - 1].hasUnbounded = true; // quantified group repeats too
         i += q.len;
+      } else if (group.hasUnbounded && stack.length) {
+        // An inner unbounded quantifier propagates to the enclosing group even when this group is not
+        // itself quantified, so a wrapping group can't hide it (e.g. ((a+))+ must still be rejected).
+        stack[stack.length - 1].hasUnbounded = true;
       }
       continue;
     }

--- a/plugins.json
+++ b/plugins.json
@@ -369,7 +369,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -389,7 +389,7 @@
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.1.2/faq-bot.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.1.3/faq-bot.zip",
     "i18n": {
       "es": {
         "name": "Bot de Preguntas Frecuentes / Respuesta Automática",


### PR DESCRIPTION
## Summary

Follow-up hardening for **faq-bot**, released as **v0.1.3**.

The regex safety check added in v0.1.2 only flagged a group that was **directly** quantified. A group's "contains an unbounded quantifier" property was discarded when the group closed without a trailing quantifier, so wrapping a catastrophic pattern in an extra layer of parentheses slipped it through:

- `((a+))+`, `(((a+)))*`, `((\w+\s?))*` were **accepted** and remained catastrophic-backtracking.

The check now propagates that property to the enclosing group even when the inner group isn't itself quantified, so a wrapping group can no longer hide the nesting. Single-quantifier grouped patterns (e.g. `((ab)+)`, `(a+)`, `((cat|dog))`) are still accepted — no over-rejection.

Known, unchanged limitation (documented in code): the heuristic addresses the nested-quantifier class, not overlapping-alternation ReDoS (e.g. `(a|a)*`); the upgrade path is a linear-time engine.

## Tests
- New: `((a+))+`, `(((a+)))*`, `((\w+\s?))*` are skipped; `((ab)+)`, `(a+)`, `((cat|dog))` are kept.
- Full suite green (106 tests), `tsc --noEmit` clean, bundle packages cleanly.