### PR TITLE
fix(gsheets-logger): cap oversized cells, extend the formula guard to +/-, floor the flush interval (v0.2.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository provides:
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.1.0 | beta |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.4 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.4 | stable |
-| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.2.2 | stable |
+| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.2.3 | stable |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.0 | beta |
 <!-- END PLUGIN CATALOG -->
 

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -8,6 +8,22 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-07-02
+
+### Fixed
+
+- **Oversized cell no longer stalls logging.** A message body longer than Google Sheets' 50 000-char
+  cell limit made the whole append batch fail with a 400 that was retained and retried forever,
+  blocking all logging. Every cell is now capped at 50 000 chars, so one long message can't poison the
+  pipeline.
+- **Formula-injection guard on free-text fields extended to `+`/`-`.** A leading `+`/`-` is now quoted
+  when it is not the start of a number, so an attacker-controlled sender name or body like
+  `-IMPORTXML(…)` / `+ HYPERLINK(…)` is neutralized on CSV export, while a phone number (`+62812…`) or a
+  negative number (`-5°C`) is still written unquoted.
+- **Sub-second flush interval floored to 1s.** A finite but tiny `flushIntervalSec` (e.g. `0.001`) was
+  accepted and hot-looped the flush timer; it is now floored to 1 second (the NaN/0/negative clamp is
+  unchanged).
+
 ## [0.2.2] — 2026-06-23
 
 ### Fixed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -13,8 +13,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `gsheets-logger` |
-| **Version** | 0.2.2 |
-| **Released** | 2026-06-23 |
+| **Version** | 0.2.3 |
+| **Released** | 2026-07-02 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
@@ -24,9 +24,9 @@
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->
 
-The installed version is also visible in the OpenWA dashboard Plugins list (`v0.2.2`), via
+The installed version is also visible in the OpenWA dashboard Plugins list (`v0.2.3`), via
 `GET /plugins/gsheets-logger`, and at runtime in the enable log line and `healthCheck`
-(`GET /plugins/gsheets-logger/health` → `"v0.2.2 — N rows buffered"`).
+(`GET /plugins/gsheets-logger/health` → `"v0.2.3 — N rows buffered"`).
 
 ## Features
 
@@ -143,7 +143,7 @@ Send yourself a WhatsApp message, then confirm the pipeline end to end:
 
 1. **Events are arriving.** Call the health endpoint:
    ```
-   GET /plugins/gsheets-logger/health   →   "v0.2.2 — N rows buffered"
+   GET /plugins/gsheets-logger/health   →   "v0.2.3 — N rows buffered"
    ```
    If `N` grows, messages are reaching the plugin — the only step left is the write to Google.
 2. **Writes are succeeding.** A healthy flush logs nothing; a failed one logs
@@ -216,14 +216,18 @@ evaluates a cell as a formula. As defense-in-depth for CSV export/re-import, cel
 single quote (`'`) when they start with a formula trigger:
 
 - **ID / enum fields** (chatId, from, to, messageId, status, type): full guard — `=` `+` `-` `@` `\t` `\r`.
-- **Free-text fields** (body, senderName, error): guard `=` `@` `\t` `\r` only, so a phone number
-  (`+62812…`) or a negative number is not corrupted with a leading quote.
+- **Free-text fields** (body, senderName, error): guard `=` `@` `\t` `\r`, plus a leading `+`/`-` that
+  is not the start of a number — so a formula like `-IMPORTXML(…)` / `+ HYPERLINK(…)` is quoted while a
+  phone number (`+62812…`) or a negative number (`-5°C`) is left readable.
+
+Every cell is also capped at 50 000 characters (Google Sheets' per-cell limit), so a single oversized
+message can't fail an append batch and stall logging.
 
 The service-account JSON is marked `secret` in the config schema, so OpenWA masks it on read.
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md). Latest: **0.2.2** (2026-06-23) — clamp the flush interval / batch size to safe positive values.
+See [CHANGELOG.md](./CHANGELOG.md). Latest: **0.2.3** (2026-07-02) — cap oversized cells, extend the formula-injection guard to `+`/`-`, floor the flush interval.
 
 ## License
 

--- a/gsheets-logger/index.test.ts
+++ b/gsheets-logger/index.test.ts
@@ -36,6 +36,13 @@ test('parseConfig clamps non-numeric/non-positive flush interval and batch size 
   assert.equal(parseConfig({ ...base, flushBatchSize: 50 }).config.flushBatchSize, 50);
 });
 
+test('parseConfig floors a sub-second flush interval to >=1s (setInterval hot-loop guard)', () => {
+  const base = { spreadsheetId: 'sid', serviceAccountJson: validSa };
+  assert.equal(parseConfig({ ...base, flushIntervalSec: 0.001 }).config.flushIntervalSec, 1);
+  assert.equal(parseConfig({ ...base, flushIntervalSec: 0.5 }).config.flushIntervalSec, 1);
+  assert.equal(parseConfig({ ...base, flushIntervalSec: 10 }).config.flushIntervalSec, 10); // sane values unchanged
+});
+
 test('flushBuffer clears the buffer on success', async () => {
   const buffer = [['a'], ['b']];
   await flushBuffer(buffer, async () => {});

--- a/gsheets-logger/index.ts
+++ b/gsheets-logger/index.ts
@@ -36,7 +36,8 @@ export function parseConfig(raw: Record<string, unknown>): { config: LoggerConfi
   }
 
   // Clamp to safe positives: a non-numeric interval coerces to NaN, and setInterval(NaN) fires at ~1ms
-  // (a flush hot-loop / Sheets-quota burn). A NaN batch size silently disables the size trigger.
+  // (a flush hot-loop / Sheets-quota burn). A NaN batch size silently disables the size trigger. A finite
+  // but sub-second interval (e.g. 0.001) is likewise a hot-loop, so floor it to 1s.
   const flushIntervalSec = Number(raw.flushIntervalSec ?? 5);
   const flushBatchSize = Number(raw.flushBatchSize ?? 20);
   return {
@@ -44,7 +45,7 @@ export function parseConfig(raw: Record<string, unknown>): { config: LoggerConfi
       serviceAccountJson,
       spreadsheetId,
       sheetTab: String(raw.sheetTab ?? 'Logs'),
-      flushIntervalSec: Number.isFinite(flushIntervalSec) && flushIntervalSec > 0 ? flushIntervalSec : 5,
+      flushIntervalSec: Number.isFinite(flushIntervalSec) && flushIntervalSec > 0 ? Math.max(1, flushIntervalSec) : 5,
       flushBatchSize: Number.isFinite(flushBatchSize) && flushBatchSize >= 1 ? flushBatchSize : 20,
     },
     sa,

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gsheets-logger",
   "name": "Google Sheets Logger",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Logs WhatsApp message events to a Google Sheet via a service account.",

--- a/gsheets-logger/row.test.ts
+++ b/gsheets-logger/row.test.ts
@@ -61,15 +61,35 @@ test('sanitizes formula-injection in attacker-controlled cells', () => {
   assert.equal(row[5], '62811@c.us');                       // benign value untouched
 });
 
-test('free-text fields keep a leading + or -; id fields stay fully guarded', () => {
+test('free-text quotes a formula-like leading +/- but preserves a phone/number; id fields stay fully guarded', () => {
   const row = buildRow({
     event: 'message:received', sessionId: 's1', timestamp: T, source: 'Engine',
     data: { id: 'M9', from: '+62811@c.us', to: 'me', chatId: '62811@c.us',
             body: '+62812 call me', type: 'text', fromMe: false, isGroup: false,
-            contact: { pushName: '-Boss' } },
+            contact: { pushName: '-IMPORTXML("http://evil")' } },
   });
-  assert.equal(row[10], '+62812 call me'); // body: '+' NOT quoted (free text)
-  assert.equal(row[7], '-Boss');           // senderName: '-' NOT quoted (free text)
-  assert.equal(row[5], `'+62811@c.us`);    // from: id field, '+' STILL quoted (full guard)
-  assert.equal(row[6], 'me');              // benign id untouched
+  assert.equal(row[10], '+62812 call me');            // body: '+' before a digit = phone number, NOT quoted
+  assert.equal(row[7], `'-IMPORTXML("http://evil")`); // senderName: '-' before a letter = formula, quoted
+  assert.equal(row[5], `'+62811@c.us`);               // from: id field, '+' STILL quoted (full guard)
+  assert.equal(row[6], 'me');                         // benign id untouched
+});
+
+test('free-text keeps a negative number but quotes plus-then-space-then-formula', () => {
+  const row = buildRow({
+    event: 'message:received', sessionId: 's1', timestamp: T, source: 'Engine',
+    data: { id: 'M9', from: 'x', to: 'y', chatId: 'c', type: 'text', fromMe: false, isGroup: false,
+            body: '-5 degrees today', contact: { pushName: '+ IMPORTXML("http://evil")' } },
+  });
+  assert.equal(row[10], '-5 degrees today');            // '-5' is a number → NOT quoted
+  assert.equal(row[7], `'+ IMPORTXML("http://evil")`);  // '+ ' (space after) is not a number → quoted
+});
+
+test('caps an oversized free-text cell to the Google Sheets 50000-char limit', () => {
+  const big = 'a'.repeat(60000);
+  const row = buildRow({
+    event: 'message:received', sessionId: 's1', timestamp: T, source: 'Engine',
+    data: { id: 'M9', from: 'x', to: 'y', chatId: 'c', body: big, type: 'text', fromMe: false, isGroup: false },
+  });
+  // A single over-limit cell would 400 the whole append batch and stall all logging; cap it so it can't.
+  assert.equal(row[10].length, 50000);
 });

--- a/gsheets-logger/row.ts
+++ b/gsheets-logger/row.ts
@@ -8,6 +8,13 @@ export const COLUMNS = [
 type FailedPayload = { sessionId?: string; error?: string; input?: { chatId?: string; text?: string } };
 type AckPayload = { messageId?: string; status?: string };
 
+// Google Sheets rejects a cell longer than 50 000 chars with a 400 that fails the whole append batch;
+// one over-limit inbound body would then stall all logging (the batch is retained and retried forever).
+// Cap every cell as the final step so a single long message can't poison the pipeline. Applied after the
+// quote prefix so the guarded prefix is never truncated away.
+const MAX_CELL = 50000;
+const cap = (s: string): string => (s.length > MAX_CELL ? s.slice(0, MAX_CELL) : s);
+
 // Neutralize CSV / spreadsheet formula injection on export/re-import (values are already written
 // with valueInputOption=RAW, so Sheets never evaluates them — this is defense-in-depth for CSV
 // round-trips). A leading single quote makes a spreadsheet treat the cell as literal text.
@@ -16,16 +23,16 @@ type AckPayload = { messageId?: string; status?: string };
 // a leading + - = @ is never legitimate.
 function strId(value: unknown): string {
   const s = value == null ? '' : String(value);
-  return /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+  return cap(/^[=+\-@\t\r]/.test(s) ? `'${s}` : s);
 }
 
-// `strText` is for free-text fields (message body, sender name, error). It omits `+` and `-` because
-// those legitimately start human content (e.g. a phone number "+62812…" or "-5°C") and quoting them
-// corrupts the value on CSV export. `=` and `@` (plus tab/CR) remain guarded — they never start
-// normal prose and are the meaningful formula-injection vectors.
+// `strText` is for free-text fields (message body, sender name, error). A leading `+`/`-` is quoted
+// only when it is NOT the start of a number (`(?![\d.])`), so a phone number "+62812…" or "-5°C" stays
+// readable while a formula like "-IMPORTXML(…)" / "+ HYPERLINK(…)" is neutralized. `=` and `@` (plus
+// tab/CR) never start normal prose and are always guarded.
 function strText(value: unknown): string {
   const s = value == null ? '' : String(value);
-  return /^[=@\t\r]/.test(s) ? `'${s}` : s;
+  return cap(/^[=@\t\r]/.test(s) || /^[+\-](?![\d.])/.test(s) ? `'${s}` : s);
 }
 
 export function buildRow(ctx: HookContext): string[] {

--- a/plugins.json
+++ b/plugins.json
@@ -810,7 +810,7 @@
   {
     "id": "gsheets-logger",
     "name": "Google Sheets Logger",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "type": "extension",
     "status": "stable",
     "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -826,11 +826,11 @@
     ],
     "minOpenWAVersion": "0.6.1",
     "testedOpenWAVersion": "0.6.1",
-    "releasedAt": "2026-06-23",
+    "releasedAt": "2026-07-02",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.2.2/gsheets-logger.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.2.3/gsheets-logger.zip",
     "i18n": {
       "es": {
         "name": "Registrador en Google Sheets",


### PR DESCRIPTION
## What

Three robustness fixes to `gsheets-logger`, all previously able to silently degrade logging.

## Changes

- **Oversized cell no longer stalls logging.** A message body over Google Sheets' 50 000-char per-cell limit made the whole `values.append` batch fail with a `400`, which was retained and retried on every tick — blocking *all* subsequent logging until the 5 000-row buffer cap evicted it (dropping legitimate rows too). Every cell is now capped at 50 000 chars (after the formula-guard prefix), so one long inbound message can't poison the pipeline.
- **Formula-injection guard on free-text fields extended to `+`/`-`.** `senderName` (attacker-controlled push name), `body`, and `error` previously quoted only `= @ \t \r`. A leading `+`/`-` is now also quoted **when it is not the start of a number**, so `-IMPORTXML(…)` / `+ HYPERLINK(…)` is neutralized on CSV export/re-import while a phone number (`+62812…`) or a negative number (`-5°C`) stays unquoted. ID/enum fields remain fully guarded.
- **Sub-second flush interval floored to 1s.** A finite but tiny `flushIntervalSec` (e.g. `0.001`) passed the existing `>0` check and hot-looped the flush timer. It is now floored to 1 second; the NaN/0/negative clamp is unchanged.

## Tests

Updated the free-text formula test to assert the new precise behavior (numbers preserved, formula-like `+`/`-` quoted) and added tests for the 50 000-char cell cap and the sub-second interval floor. Full suite green (163/163), typecheck clean, `catalog --check` up to date. Bumped to **v0.2.3**.