### PR TITLE
fix(voice-transcription): isolate delivery sinks and validate the media mimetype (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository provides:
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.4 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.4 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.2.2 | stable |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.0 | beta |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.1 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`

--- a/plugins.json
+++ b/plugins.json
@@ -1005,7 +1005,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -1023,11 +1023,11 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.7.3",
-    "releasedAt": "2026-06-25",
+    "releasedAt": "2026-07-02",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.0.0/voice-transcription.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.0.1/voice-transcription.zip",
     "i18n": {
       "es": {
         "name": "Transcripción de Notas de Voz",

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,7 +6,18 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
-## [1.0.0] — 2026-06-25
+## [1.0.1] — 2026-07-02
+
+### Fixed
+
+- **A webhook-delivery failure no longer suppresses the in-chat transcript.** When both
+  `deliveryWebhookUrl` and `chatDelivery` were configured, a transient webhook error threw before the
+  chat send, so the transcript reached neither channel. The two sinks are now isolated: a webhook failure
+  is warned and the in-chat delivery still runs.
+- **Untrusted media mimetype is validated before it reaches the STT upload's multipart headers.** The
+  inbound `mimetype` is now accepted only as a well-formed `type/subtype` token (codec suffix stripped);
+  anything else — including a CRLF-bearing value — falls back to `audio/ogg`. The part filename is already
+  fixed to `voice.ogg`, so valid formats (e.g. `audio/ogg; codecs=opus`) are unaffected.
 
 ### Added
 

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -13,8 +13,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.0.0 |
-| **Released** | 2026-06-25 |
+| **Version** | 1.0.1 |
+| **Released** | 2026-07-02 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",

--- a/voice-transcription/openai-stt.client.test.ts
+++ b/voice-transcription/openai-stt.client.test.ts
@@ -1,7 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { PluginNetCapability, PluginNetRequestInit, PluginNetResponse } from '../types/openwa';
-import { OpenAiSttClient } from './openai-stt.client.ts';
+import { OpenAiSttClient, sanitizeContentType } from './openai-stt.client.ts';
+
+test('sanitizeContentType keeps a valid mimetype (codec-stripped) but rejects CRLF / garbage', () => {
+  assert.equal(sanitizeContentType('audio/ogg; codecs=opus'), 'audio/ogg'); // real PTT — codec stripped, kept
+  assert.equal(sanitizeContentType('audio/mpeg'), 'audio/mpeg');
+  assert.equal(sanitizeContentType('audio/x-wav'), 'audio/x-wav');
+  assert.equal(sanitizeContentType('audio/vnd.wave'), 'audio/vnd.wave');
+  // A CRLF-bearing mimetype must not reach the multipart part headers verbatim.
+  assert.equal(sanitizeContentType('audio/ogg\r\nContent-Disposition: form-data; name="prompt"'), 'audio/ogg');
+  assert.equal(sanitizeContentType(''), 'audio/ogg');
+  assert.equal(sanitizeContentType('not a mime type'), 'audio/ogg');
+});
 
 function res(partial: { ok?: boolean; status?: number; body?: string }): PluginNetResponse {
   return {

--- a/voice-transcription/openai-stt.client.ts
+++ b/voice-transcription/openai-stt.client.ts
@@ -1,6 +1,14 @@
 import type { PluginNetCapability } from '../types/openwa';
 import { buildMultipartBody, MultipartField } from './multipart.ts';
 
+/** Derive the multipart part Content-Type from an untrusted media mimetype: strip the codec suffix, then
+ *  accept only a well-formed `type/subtype` token. Anything else (empty, spaces, an injected CRLF) falls
+ *  back to audio/ogg — the part filename is fixed to voice.ogg, so the decoder keys off that regardless. */
+export function sanitizeContentType(mimetype: string): string {
+  const token = mimetype.split(';')[0].trim();
+  return /^[\w.+-]+\/[\w.+-]+$/.test(token) ? token : 'audio/ogg';
+}
+
 export interface SttResult {
   text: string;
   language?: string;
@@ -80,7 +88,7 @@ export class OpenAiSttClient implements SttProvider {
     // Strip the codec suffix ("audio/ogg; codecs=opus" → "audio/ogg") and always name the part
     // `voice.ogg`: OpenAI-compatible servers key the decoder off the filename extension and reject a
     // bare ".opus", but accept ogg/oga.
-    const contentType = mimetype.split(';')[0].trim() || 'audio/ogg';
+    const contentType = sanitizeContentType(mimetype);
     const formBody = buildMultipartBody(boundary, fields, [
       { name: 'file', filename: 'voice.ogg', contentType, data: audio },
     ]);

--- a/voice-transcription/transcription.coordinator.test.ts
+++ b/voice-transcription/transcription.coordinator.test.ts
@@ -205,3 +205,11 @@ test('works chat-only when no webhook delivery is configured', async () => {
   await assert.doesNotReject(co.handle('s1', voiceMsg()));
   assert.equal(chatSends.length, 1);
 });
+
+test('a webhook delivery failure does not suppress the in-chat transcript delivery', async () => {
+  // The two sinks are independent: a 502 from the delivery webhook must not swallow the chat send.
+  const { co, chatSends, warns } = setup({ deliveryThrows: true, chatDelivery: 'self' });
+  await assert.doesNotReject(co.handle('s1', voiceMsg()));
+  assert.equal(chatSends.length, 1);   // chat sink still fired despite the webhook failure
+  assert.ok(warns.length >= 1);        // the webhook failure is still warned
+});

--- a/voice-transcription/transcription.coordinator.ts
+++ b/voice-transcription/transcription.coordinator.ts
@@ -149,7 +149,18 @@ export class TranscriptionCoordinator {
       ...(o.reason ? { reason: o.reason } : {}),
       ...(o.transcription ? { transcription: o.transcription } : {}),
     };
-    if (this.deps.delivery) await this.deps.delivery.deliver(payload);
+    // The webhook and in-chat deliveries are independent sinks — isolate the webhook so a failing
+    // delivery endpoint can't swallow the in-chat transcript (and vice versa is unaffected: chat is last).
+    if (this.deps.delivery) {
+      try {
+        await this.deps.delivery.deliver(payload);
+      } catch (err) {
+        this.deps.logger.warn('Transcript webhook delivery failed', {
+          messageId: msg.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
     if (o.status === 'completed' && o.text && this.deps.chat && this.deps.chatDelivery !== 'off') {
       if (this.deps.chatDelivery === 'self') await this.deps.chat.sendText(sessionId, msg.to, o.text);
       else await this.deps.chat.reply(sessionId, msg.chatId, msg.id, o.text);


### PR DESCRIPTION
## What

Two fixes to `voice-transcription`: independent delivery channels no longer fail together, and the untrusted media mimetype is validated before it reaches the STT upload.

## Changes

- **Webhook and in-chat delivery are now isolated.** `emit` awaited the delivery-webhook POST before the in-chat send, so with both `deliveryWebhookUrl` and `chatDelivery` configured, a transient webhook error (e.g. a 502) threw and skipped the chat send — a completed transcript reached neither channel. The webhook sink is now wrapped: a failure is warned and the in-chat delivery still runs.
- **Media mimetype validated before the multipart upload.** The inbound `mimetype` (sender-controlled) flowed into the STT request's multipart part headers with only a codec-suffix strip, so an interior CRLF survived into the body. It is now accepted only as a well-formed `type/subtype` token and otherwise falls back to `audio/ogg`. Valid formats like `audio/ogg; codecs=opus` are unaffected (the part filename is already fixed to `voice.ogg`).

## Tests

Added a unit test for the mimetype sanitizer (valid kept, CRLF/garbage → `audio/ogg`) and a coordinator test asserting a webhook failure no longer suppresses the in-chat transcript. Full suite green (162/162), typecheck clean, `catalog --check` up to date. Bumped to **v1.0.1**.