### PR TITLE
fix(chat-flow): per-participant group flows and an expired-state sweep (v1.0.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository provides:
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.1.2 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.3 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.4 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.1.0 | beta |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.4 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.4 | stable |

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,7 +8,17 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
-## [1.0.3] — 2026-06-23
+## [1.0.4] — 2026-07-02
+
+### Fixed
+
+- **Group flows are now per-participant.** With `respondInGroups` enabled, flow state was keyed by the
+  group chat alone, so every member shared one menu position — one member's reply advanced or reset the
+  flow another member was walking. State is now scoped to `(chat, sender)` in a group; 1:1 chats are
+  unchanged. (Existing in-progress group flows reset once on upgrade.)
+- **Abandoned flow states are reclaimed.** Per-state expiry only ran when a chat messaged again, so a
+  flow started and then abandoned lingered in plugin storage indefinitely. The plugin now sweeps expired
+  states on enable and periodically (every 30 min; state TTL is 15 min).
 
 ### Fixed
 

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -13,8 +13,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.0.3 |
-| **Released** | 2026-06-23 |
+| **Version** | 1.0.4 |
+| **Released** | 2026-07-02 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
@@ -92,7 +92,7 @@ plugin's **Flow editor**.
 | `greeting` | yes | — | The greeting + menu sent when the flow starts |
 | `options` | yes | — | The menu tree: array of `{ key, text, options? }` nodes (nests arbitrarily) |
 | `trigger` | no | `""` | Word that starts the flow (case-insensitive); empty = any message starts it |
-| `respondInGroups` | no | `false` | Whether to run in group chats |
+| `respondInGroups` | no | `false` | Whether to run in group chats (each participant walks their own flow) |
 
 ## Compatibility
 

--- a/chat-flow/flow-engine.test.ts
+++ b/chat-flow/flow-engine.test.ts
@@ -172,3 +172,29 @@ test('a prototype-property name as input is an invalid option, never a false mat
     assert.deepEqual((storage.get(key) as { path: string[] }).path, [], `${evil} keeps the flow active`);
   }
 });
+
+test('group mode: different authors in the same chat get independent flow state', async () => {
+  const { ctx, storage } = makeCtx();
+  // alice and bob both message the same group; the 7th arg (actor) scopes state per participant.
+  await FlowEngine.processMessage(ctx, xyz, 'sess', 'grp@g.us', 'hello', 'a1', 'alice@c.us'); // alice: greeting
+  await FlowEngine.processMessage(ctx, xyz, 'sess', 'grp@g.us', 'hello', 'b1', 'bob@c.us');   // bob: greeting
+  // alice picks option 2 (which has a sub-option) → only ALICE's path advances to ['2'].
+  const r = await FlowEngine.processMessage(ctx, xyz, 'sess', 'grp@g.us', '2', 'a2', 'alice@c.us');
+  assert.equal(r, true);
+  const aliceKey = 'state__sess__grp@g.us|alice@c.us';
+  const bobKey = 'state__sess__grp@g.us|bob@c.us';
+  assert.deepEqual((storage.get(aliceKey) as { path: string[] }).path, ['2']); // alice advanced
+  assert.deepEqual((storage.get(bobKey) as { path: string[] }).path, []);      // bob untouched
+});
+
+test('sweepExpired deletes state entries past the TTL and keeps fresh ones', async () => {
+  const { ctx, storage } = makeCtx();
+  storage.set('state__s__fresh', { path: [], lastActive: Date.now() });
+  storage.set('state__s__stale', { path: [], lastActive: Date.now() - 20 * 60 * 1000 }); // 20 min > 15 min TTL
+  storage.set('other__key', { keep: true }); // non-state key must be left alone
+  const removed = await FlowEngine.sweepExpired(ctx);
+  assert.equal(removed, 1);
+  assert.equal(storage.has('state__s__stale'), false);
+  assert.equal(storage.has('state__s__fresh'), true);
+  assert.equal(storage.has('other__key'), true);
+});

--- a/chat-flow/flow-engine.ts
+++ b/chat-flow/flow-engine.ts
@@ -24,8 +24,12 @@ export class FlowEngine {
 
   /**
    * Process an incoming message and send auto-replies according to `flow` (the resolved per-session
-   * config). Returns true if a reply was sent, false otherwise. Serializes per (session, chat) so
-   * concurrent messages for the same chat can't interleave the state read→write.
+   * config). Returns true if a reply was sent, false otherwise. Serializes per (session, conversation)
+   * so concurrent messages for the same conversation can't interleave the state read→write.
+   *
+   * `actor` scopes the flow state to a participant: in a group, pass the sender so each member walks
+   * their own menu (a group chat is shared by many people); in a 1:1 chat leave it undefined so the
+   * state key is just the chatId (unchanged). Replies always go to `chatId`.
    */
   public static async processMessage(
     context: PluginContext,
@@ -34,13 +38,17 @@ export class FlowEngine {
     chatId: string,
     messageBody: string,
     messageId: string,
+    actor?: string,
   ): Promise<boolean> {
+    const conversation = actor ? `${chatId}|${actor}` : chatId;
     // The bounded re-process inside the body calls processLocked directly (bypassing this lock) so a
-    // chat never waits on its own still-pending chain entry (self-deadlock). Store a settled tail so a
-    // rejection can't wedge the chain, and evict the key once the chain drains.
-    const lockKey = `${sessionId}__${chatId}`;
+    // conversation never waits on its own still-pending chain entry (self-deadlock). Store a settled
+    // tail so a rejection can't wedge the chain, and evict the key once the chain drains.
+    const lockKey = `${sessionId}__${conversation}`;
     const prev = this.locks.get(lockKey) ?? Promise.resolve();
-    const run = prev.then(() => this.processLocked(context, flow, sessionId, chatId, messageBody, messageId, 0));
+    const run = prev.then(() =>
+      this.processLocked(context, flow, sessionId, chatId, conversation, messageBody, messageId, 0),
+    );
     const tail = run.catch(() => {});
     this.locks.set(lockKey, tail);
     try {
@@ -50,11 +58,28 @@ export class FlowEngine {
     }
   }
 
+  /** Delete persisted flow states whose last activity is older than the TTL. Lazy per-key expiry only
+   *  runs when a conversation messages again, so an abandoned flow would otherwise linger forever; the
+   *  plugin calls this periodically. Returns the number of entries removed. */
+  public static async sweepExpired(context: PluginContext): Promise<number> {
+    const keys = (await context.storage.list('state__')).filter(k => k.startsWith('state__'));
+    let removed = 0;
+    for (const k of keys) {
+      const s = await context.storage.get<UserState>(k);
+      if (s && Date.now() - s.lastActive > this.TIMEOUT_MS) {
+        await context.storage.delete(k);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
   private static async processLocked(
     context: PluginContext,
     flow: SessionFlow,
     sessionId: string,
     chatId: string,
+    conversation: string,
     messageBody: string,
     messageId: string,
     depth = 0,
@@ -62,7 +87,7 @@ export class FlowEngine {
     context.logger.debug('[FlowEngine] Processing message', { sessionId, chatId, body: messageBody });
 
     const input = messageBody.trim();
-    const stateKey = `state__${sessionId}__${chatId}`.replace(/:/g, '_');
+    const stateKey = `state__${sessionId}__${conversation}`.replace(/:/g, '_');
     let state = await context.storage.get<UserState>(stateKey);
     context.logger.debug('[FlowEngine] Loaded state', { stateKey, state });
 
@@ -113,8 +138,8 @@ export class FlowEngine {
           return false;
         }
         // Recurse on the locked body, NOT processMessage — re-entering the lock would deadlock on this
-        // chat's own still-pending chain entry.
-        return this.processLocked(context, flow, sessionId, chatId, messageBody, messageId, depth + 1);
+        // conversation's own still-pending chain entry.
+        return this.processLocked(context, flow, sessionId, chatId, conversation, messageBody, messageId, depth + 1);
       }
     }
 

--- a/chat-flow/index.ts
+++ b/chat-flow/index.ts
@@ -41,20 +41,44 @@ export function parseConfig(raw: Record<string, unknown>): ChatFlowConfig {
   return { flow: { trigger, greeting, options }, respondInGroups: raw.respondInGroups === true };
 }
 
+/** How often to sweep abandoned flow states from storage (state TTL is 15 min). */
+const SWEEP_INTERVAL_MS = 30 * 60 * 1000;
+
 export default class ChatFlow implements IPlugin {
   private config: ChatFlowConfig | null = null;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
 
   async onEnable(ctx: PluginContext): Promise<void> {
     this.config = parseConfig(ctx.config);
     ctx.registerHook('message:received', hook =>
       this.onMessage(ctx, hook as HookContext<IncomingMessage>),
     );
+    // Reclaim states abandoned before this enable, then keep sweeping — lazy per-key expiry only fires
+    // when a conversation messages again, so an abandoned flow would otherwise linger in storage forever.
+    void FlowEngine.sweepExpired(ctx).catch(() => {});
+    this.sweepTimer = setInterval(() => void FlowEngine.sweepExpired(ctx).catch(() => {}), SWEEP_INTERVAL_MS);
+    this.sweepTimer.unref?.();
   }
 
   // The platform passes the new config as the 2nd arg, but for a sessionScoped plugin ctx.config is already
   // the resolved per-session slice — read that (re-parsing _newConfig would lose the per-session merge).
   async onConfigChange(ctx: PluginContext, _newConfig: Record<string, unknown>): Promise<void> {
     this.config = parseConfig(ctx.config);
+  }
+
+  async onDisable(): Promise<void> {
+    this.stopSweep();
+  }
+
+  async onUnload(): Promise<void> {
+    this.stopSweep();
+  }
+
+  private stopSweep(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
   }
 
   private async onMessage(ctx: PluginContext, hook: HookContext<IncomingMessage>): Promise<HookResult> {
@@ -64,7 +88,9 @@ export default class ChatFlow implements IPlugin {
     if (m.fromMe || typeof m.body !== 'string' || !m.chatId || !m.id) return { continue: true };
     if (m.isGroup && !cfg.respondInGroups) return { continue: true };
     try {
-      const handled = await FlowEngine.processMessage(ctx, cfg.flow, hook.sessionId, m.chatId, m.body, m.id);
+      // In a group, scope flow state to the sender so members don't clobber each other's menu position.
+      const actor = m.isGroup ? m.author : undefined;
+      const handled = await FlowEngine.processMessage(ctx, cfg.flow, hook.sessionId, m.chatId, m.body, m.id, actor);
       return { continue: !handled };
     } catch (err) {
       ctx.logger.error('chat-flow: flow processing failed', err);

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",

--- a/plugins.json
+++ b/plugins.json
@@ -197,7 +197,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -214,11 +214,11 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.7.0",
-    "releasedAt": "2026-06-23",
+    "releasedAt": "2026-07-02",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.0.3/chat-flow.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.0.4/chat-flow.zip",
     "i18n": {
       "es": {
         "name": "Flujo de Chat",


### PR DESCRIPTION
## What

Two fixes to `chat-flow`: group flows are now per-participant, and abandoned flow state no longer accumulates in storage.

## Changes

- **Per-participant group flows.** Flow state (and the per-conversation lock) was keyed by the group chat id alone, so with `respondInGroups` enabled every member shared a single menu position — one member's reply advanced or reset the flow another member was walking. State is now scoped to `(chat, sender)` in a group. 1:1 chats are unaffected (the key is unchanged), and replies still go to the chat. Existing in-progress group flows reset once on upgrade.
- **Expired-state sweep.** Per-state TTL expiry only fired when a conversation messaged again, so a flow that was started and then abandoned lingered in plugin storage indefinitely. Added `FlowEngine.sweepExpired`, run on enable and on a 30-minute interval (state TTL is 15 min); the timer is unref'd and cleared on disable/unload.

## Tests

Added a test that two authors in the same group keep independent flow state, and a test that `sweepExpired` removes past-TTL entries while keeping fresh and non-state keys. Full suite green (162/162), typecheck clean, `catalog --check` up to date. Bumped to **v1.0.4**.