### PR TITLE
fix(chat-flow): guard the sweep delete race and make the sweep timer idempotent (v1.0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository provides:
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.1.2 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.4 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.0.5 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.1.1 | beta |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.5 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.5 | stable |

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,20 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.0.5] — 2026-07-02
+
+### Fixed
+
+- The periodic expired-state sweep now re-reads an entry immediately before deleting it, so a flow
+  re-created by a message in the gap between the scan and the delete is not wiped.
+- Restored the `## [1.0.3]` changelog heading that a prior edit dropped (its entries had been folded
+  under 1.0.4 by mistake).
+
+### Changed
+
+- `onEnable` clears any existing sweep timer before starting a new one (defensive idempotency, matching
+  the other timer-using plugins).
+
 ## [1.0.4] — 2026-07-02
 
 ### Fixed
@@ -19,6 +33,8 @@ The version here always matches `manifest.json`'s `version`.
 - **Abandoned flow states are reclaimed.** Per-state expiry only ran when a chat messaged again, so a
   flow started and then abandoned lingered in plugin storage indefinitely. The plugin now sweeps expired
   states on enable and periodically (every 30 min; state TTL is 15 min).
+
+## [1.0.3] — 2026-06-23
 
 ### Fixed
 

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -13,7 +13,7 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.0.4 |
+| **Version** | 1.0.5 |
 | **Released** | 2026-07-02 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |

--- a/chat-flow/flow-engine.test.ts
+++ b/chat-flow/flow-engine.test.ts
@@ -198,3 +198,23 @@ test('sweepExpired deletes state entries past the TTL and keeps fresh ones', asy
   assert.equal(storage.has('state__s__fresh'), true);
   assert.equal(storage.has('other__key'), true);
 });
+
+test('sweepExpired does not delete a state refreshed between the scan and the delete (race guard)', async () => {
+  const NOW = Date.now();
+  const stale = { path: [], lastActive: NOW - 20 * 60 * 1000 }; // > 15-min TTL
+  const fresh = { path: [], lastActive: NOW };
+  let gets = 0;
+  let deleted = false;
+  const ctx = {
+    storage: {
+      list: async () => ['state__s__x'],
+      get: async () => (++gets === 1 ? stale : fresh), // scan sees stale; the re-check sees fresh
+      delete: async () => { deleted = true; },
+      set: async () => {},
+    },
+    logger: { log() {}, debug() {}, warn() {}, error() {} },
+  } as unknown as import('../types/openwa').PluginContext;
+  const removed = await FlowEngine.sweepExpired(ctx);
+  assert.equal(removed, 0);        // the re-read saw fresh state → the live flow is not wiped
+  assert.equal(deleted, false);
+});

--- a/chat-flow/flow-engine.ts
+++ b/chat-flow/flow-engine.ts
@@ -63,10 +63,15 @@ export class FlowEngine {
    *  plugin calls this periodically. Returns the number of entries removed. */
   public static async sweepExpired(context: PluginContext): Promise<number> {
     const keys = (await context.storage.list('state__')).filter(k => k.startsWith('state__'));
+    const expired = (s: UserState | null): boolean => !!s && Date.now() - s.lastActive > this.TIMEOUT_MS;
     let removed = 0;
     for (const k of keys) {
-      const s = await context.storage.get<UserState>(k);
-      if (s && Date.now() - s.lastActive > this.TIMEOUT_MS) {
+      if (!expired(await context.storage.get<UserState>(k))) continue;
+      // Re-read immediately before deleting: a message may have re-created fresh state for this key since
+      // the scan. Only delete if it is STILL expired, so a live flow isn't wiped.
+      // ponytail: this narrows the check→delete race to a tiny window; a per-key lock would close it fully
+      // but isn't worth it for a 30-min GC of already-stale state that self-heals on the next message.
+      if (expired(await context.storage.get<UserState>(k))) {
         await context.storage.delete(k);
         removed++;
       }

--- a/chat-flow/index.ts
+++ b/chat-flow/index.ts
@@ -56,6 +56,7 @@ export default class ChatFlow implements IPlugin {
     // Reclaim states abandoned before this enable, then keep sweeping — lazy per-key expiry only fires
     // when a conversation messages again, so an abandoned flow would otherwise linger in storage forever.
     void FlowEngine.sweepExpired(ctx).catch(() => {});
+    this.stopSweep(); // idempotent: clear any timer from a prior enable before starting a fresh one
     this.sweepTimer = setInterval(() => void FlowEngine.sweepExpired(ctx).catch(() => {}), SWEEP_INTERVAL_MS);
     this.sweepTimer.unref?.();
   }

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",

--- a/plugins.json
+++ b/plugins.json
@@ -197,7 +197,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -218,7 +218,7 @@
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.0.4/chat-flow.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.0.5/chat-flow.zip",
     "i18n": {
       "es": {
         "name": "Flujo de Chat",


### PR DESCRIPTION
## What

Follow-up hardening to the v1.0.4 per-participant/sweep change, from a self-review pass.

## Changes

- **Sweep delete race.** The periodic expired-state sweep read an entry, found it past the TTL, then deleted it — with an await in between. A message arriving in that gap could re-create fresh state for the same key, which the sweep would then wipe (a rare, self-healing race). The sweep now re-reads the entry immediately before deleting and only deletes if it is *still* expired.
- **Idempotent sweep timer.** `onEnable` now clears any existing timer before starting a new one, matching the pattern the other timer-using plugins already follow (defensive; the loader already prevents a double-enable, so this is belt-and-suspenders).
- **Changelog fix.** Restore the `## [1.0.3]` heading that the v1.0.4 changelog edit dropped, so its entries are no longer folded under 1.0.4.

## Tests

Added a test that a state refreshed between the scan and the delete is not wiped. Full suite green (178/178), typecheck clean, `catalog --check` up to date. Bumped to **v1.0.5**.