### PR TITLE
docs: record OpenWA v0.8.1 as the tested version across all plugins

### DIFF
--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -18,7 +18,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.2 (tested 0.6.2) |
+| **Requires OpenWA** | ≥ 0.6.2 (tested 0.8.1) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["after-hours", "business-hours", "away", "auto-reply", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.6.2",
-  "testedOpenWAVersion": "0.6.2",
+  "testedOpenWAVersion": "0.8.1",
   "provides": ["auto-reply"],
   "permissions": ["messages:send"],
   "sessions": ["*"],

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.7.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.7.0",
+  "testedOpenWAVersion": "0.8.1",
   "provides": [
     "auto-reply"
   ],

--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -17,7 +17,7 @@ mirror it. Runs sandboxed in the plugin worker; no server, no extra port.
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.0 (tested 0.8.0) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested 0.8.1) |
 | **Keywords** | chatwoot, helpdesk, inbox, handover, two-way, agent, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chatwoot-adapter](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter) |
 <!-- END DETAILS -->

--- a/chatwoot-adapter/manifest.json
+++ b/chatwoot-adapter/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["chatwoot", "helpdesk", "inbox", "handover", "two-way", "agent", "whatsapp", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.8.0",
-  "testedOpenWAVersion": "0.8.0",
+  "testedOpenWAVersion": "0.8.1",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send", "webhook:ingress"],
   "net": { "allow": [], "allowConfigHosts": ["baseUrl"] },

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.6.1) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.8.1) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["faq", "auto-reply", "chatbot", "support", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.6.1",
+  "testedOpenWAVersion": "0.8.1",
   "provides": ["auto-reply"],
   "permissions": ["messages:send"],
   "sessions": ["*"],

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.7.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
 | **Keywords** | translation, libretranslate, i18n, groups, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/group-translate](https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate) |
 <!-- END DETAILS -->

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["translation", "libretranslate", "i18n", "groups", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.7.0",
+  "testedOpenWAVersion": "0.8.1",
   "provides": ["translation"],
   "permissions": ["messages:send", "engine:read", "net:fetch"],
   "net": { "allow": ["localhost:7001"] },

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.6.1) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.8.1) |
 | **Keywords** | google-sheets, logging, audit, crm, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["google-sheets", "logging", "audit", "crm", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.6.1",
+  "testedOpenWAVersion": "0.8.1",
   "provides": ["message-logging"],
   "permissions": [],
   "sessions": ["*"],

--- a/plugins.json
+++ b/plugins.json
@@ -17,7 +17,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.2",
-    "testedOpenWAVersion": "0.6.2",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-06-23",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -213,7 +213,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.7.0",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -386,7 +386,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.0",
-    "testedOpenWAVersion": "0.8.0",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "chatwoot-adapter",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -411,7 +411,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.6.1",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -582,7 +582,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.7.0",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -825,7 +825,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.6.1",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1022,7 +1022,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.7.3",
+    "testedOpenWAVersion": "0.8.1",
     "releasedAt": "2026-07-02",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.7.3) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
 | **Keywords** | transcription, speech-to-text, stt, whisper, voice, audio, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/voice-transcription](https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription) |
 <!-- END DETAILS -->

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["transcription", "speech-to-text", "stt", "whisper", "voice", "audio", "whatsapp", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.7.3",
+  "testedOpenWAVersion": "0.8.1",
   "provides": ["transcription"],
   "permissions": ["net:fetch"],
   "net": { "allow": ["localhost", "127.0.0.1", "api.groq.com:443", "api.openai.com:443"] },


### PR DESCRIPTION
## What

Bumps `testedOpenWAVersion` to **0.8.1** in all seven plugin manifests and regenerates the catalog (`plugins.json`) and each README **Details** block accordingly.

## Why

All seven plugins were verified against OpenWA v0.8.1 — the capability session-confinement + `net.fetch` concurrency bound (#594), ingress idempotency/durability (#591), the ingress HMAC + secret-redaction hardening (#592/#593), and the ephemeral/view-once message mapping (#596) — and are compatible with no code change. Several of those changes reinforce existing plugin behavior (session-scoped sends, deterministic ingress dedup). This records that verification so the marketplace catalog shows the current tested version.

## Scope

- `testedOpenWAVersion` only. `minOpenWAVersion` floors are unchanged (each plugin's real minimum).
- **Metadata / docs only** — no plugin code or behavior change, so no plugin version bump and no new releases. Full test suite stays green (181/181), typecheck clean, `catalog --check` up to date.