### PR TITLE
fix(group-translate,voice-transcription): honor per-session config via signature-cached rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository provides:
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.1.0 | beta |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.1.0 | beta |
 | [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.1.0 | beta |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.1 | beta |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.2 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,17 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-session config overrides are now honored at message time without resetting the circuit breaker
+  on every message.** The coordinator was built once at `onEnable` and the hook read that cached
+  instance, so a per-session override (e.g. a different LibreTranslate instance or command prefix for one
+  session) set via the dashboard after enable was ignored. The hook now recomputes a signature of the
+  coordinator-affecting config fields per event and rebuilds the coordinator only when that signature
+  changes — so an override takes effect, while the LibreTranslate client's circuit-breaker state is
+  preserved across messages for an unchanged backend (a naive per-event rebuild would open/close the
+  backend anew on each call and defeat the breaker's purpose).
+
 ## [1.0.5] — 2026-07-02
 
 ### Fixed

--- a/group-translate/index.test.ts
+++ b/group-translate/index.test.ts
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type {
+  PluginContext,
+  HookContext,
+  HookResult,
+  IncomingMessage,
+  PluginNetResponse,
+} from "../types/openwa";
+import { TranslationPlugin } from "./index.ts";
+
+function makeStorage() {
+  const m = new Map<string, unknown>();
+  return {
+    get: async (k: string) => (m.has(k) ? m.get(k) : null),
+    set: async (k: string, v: unknown) => void m.set(k, v),
+    delete: async (k: string) => void m.delete(k),
+    list: async () => [...m.keys()],
+  };
+}
+
+function fakeContext(config: Record<string, unknown>) {
+  let hook:
+    | ((ctx: HookContext<IncomingMessage>) => Promise<HookResult>)
+    | undefined;
+  const net = {
+    fetch: async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "",
+        headers: {},
+        body: '[{"code":"en"}]',
+      }) as PluginNetResponse,
+  };
+  const ctx = {
+    pluginId: "group-translate",
+    manifest: { id: "group-translate" },
+    config,
+    logger: { log() {}, debug() {}, warn() {}, error() {} },
+    storage: makeStorage(),
+    registerHook: (
+      _event: string,
+      handler: (c: HookContext<IncomingMessage>) => Promise<HookResult>,
+    ) => {
+      hook = handler;
+    },
+    messages: {},
+    engine: {},
+    net,
+    hookManager: {},
+  } as unknown as PluginContext;
+  return { ctx, getHook: () => hook };
+}
+
+const engineCtx = (
+  data: Partial<IncomingMessage> = {},
+): HookContext<IncomingMessage> => ({
+  event: "message:received",
+  source: "Engine",
+  sessionId: "s1",
+  timestamp: new Date(0),
+  data: {
+    id: "m1",
+    from: "x@s.whatsapp.net",
+    to: "y@s.whatsapp.net",
+    chatId: "group@g.us",
+    body: "hello",
+    type: "text",
+    timestamp: 0,
+    fromMe: false,
+    isGroup: true,
+    author: "x@s.whatsapp.net",
+    ...data,
+  } as IncomingMessage,
+});
+
+// Regression: the message hook must rebuild the coordinator when a coordinator-affecting config field
+// changes (per-session override), and must NOT rebuild it when the config is unchanged (preserving the
+// LibreTranslate client's circuit-breaker state across messages for the same backend).
+test("coordinator rebuilds when coordinator-affecting config changes, is reused when unchanged", async () => {
+  const config: Record<string, unknown> = {
+    libretranslateUrl: "http://lt-a:7001",
+  };
+  const { ctx, getHook } = fakeContext(config);
+  const plugin = new TranslationPlugin();
+  await plugin.onEnable(ctx);
+  const coordAfterEnable = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.ok(coordAfterEnable, "coordinator built at enable");
+
+  // Fire a hook WITHOUT changing config → coordinator must be reused (circuit breaker preserved).
+  await getHook()!(engineCtx());
+  const coordUnchanged = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.strictEqual(
+    coordUnchanged,
+    coordAfterEnable,
+    "coordinator reused for unchanged config",
+  );
+
+  // Change a coordinator-affecting field (libretranslateUrl) → coordinator must rebuild on next hook fire.
+  config.libretranslateUrl = "http://lt-b:7001";
+  await getHook()!(engineCtx());
+  const coordRebuilt = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.notStrictEqual(
+    coordRebuilt,
+    coordAfterEnable,
+    "coordinator rebuilt for changed config",
+  );
+});

--- a/group-translate/index.ts
+++ b/group-translate/index.ts
@@ -7,37 +7,72 @@
  * translate calls routed through `ctx.net.fetch`. Disabled until enabled via
  * `POST /plugins/group-translate/enable`.
  */
-import type { PluginContext, IPlugin, HookContext, HookResult, IncomingMessage } from '../types/openwa';
-import { TranslationCoordinator, CoordinatorOptions } from './core/translation.coordinator';
-import { InboundMessage, TranslationLogger } from './core/ports';
-import { LibreTranslateClient } from './libretranslate.client';
-import { PluginChatGateway } from './plugin-chat.gateway';
-import { PluginConfigStore } from './plugin-config.store';
+import type {
+  PluginContext,
+  IPlugin,
+  HookContext,
+  HookResult,
+  IncomingMessage,
+} from "../types/openwa";
+import {
+  TranslationCoordinator,
+  CoordinatorOptions,
+} from "./core/translation.coordinator";
+import { InboundMessage, TranslationLogger } from "./core/ports";
+import { LibreTranslateClient } from "./libretranslate.client";
+import { PluginChatGateway } from "./plugin-chat.gateway";
+import { PluginConfigStore } from "./plugin-config.store";
 
-function readString(cfg: Record<string, unknown>, key: string, fallback: string): string {
+function readString(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: string,
+): string {
   const v = cfg[key];
-  return typeof v === 'string' && v.length > 0 ? v : fallback;
+  return typeof v === "string" && v.length > 0 ? v : fallback;
 }
-function readOptionalString(cfg: Record<string, unknown>, key: string): string | undefined {
+function readOptionalString(
+  cfg: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const v = cfg[key];
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
+  return typeof v === "string" && v.length > 0 ? v : undefined;
 }
-function readNumber(cfg: Record<string, unknown>, key: string, fallback: number): number {
+function readNumber(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
   const v = cfg[key];
-  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
 }
-function readBool(cfg: Record<string, unknown>, key: string, fallback: boolean): boolean {
+function readBool(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: boolean,
+): boolean {
   const v = cfg[key];
-  return typeof v === 'boolean' ? v : fallback;
+  return typeof v === "boolean" ? v : fallback;
 }
 
 export class TranslationPlugin implements IPlugin {
   private coordinator: TranslationCoordinator | null = null;
+  // Signature of the coordinator-affecting config last used to build `this.coordinator`. The hook
+  // recomputes this per event and rebuilds the coordinator only when it changes — so a per-session
+  // override (resolved by the host for the firing session) takes effect, WITHOUT resetting the
+  // LibreTranslate client's circuit breaker on every message (a per-event rebuild would open/close the
+  // backend anew on each call and defeat the breaker's purpose).
+  private coordinatorSignature = "";
 
   onEnable(context: PluginContext): Promise<void> {
     this.coordinator = this.buildCoordinator(context);
-    context.registerHook('message:received', ctx => this.onMessage(context, ctx as HookContext<IncomingMessage>));
-    context.logger.log('Translation plugin enabled', { action: 'translation_enabled' });
+    this.coordinatorSignature = this.configSignature(context.config);
+    context.registerHook("message:received", (ctx) =>
+      this.onMessage(context, ctx as HookContext<IncomingMessage>),
+    );
+    context.logger.log("Translation plugin enabled", {
+      action: "translation_enabled",
+    });
     return Promise.resolve();
   }
 
@@ -45,8 +80,26 @@ export class TranslationPlugin implements IPlugin {
     // Rebuild the coordinator so a config edit (e.g. a new LibreTranslate URL/key saved from the
     // dashboard) takes effect immediately, without a disable/enable cycle.
     this.coordinator = this.buildCoordinator(context);
-    context.logger.log('Translation plugin config updated', { action: 'translation_config_changed' });
+    this.coordinatorSignature = this.configSignature(context.config);
+    context.logger.log("Translation plugin config updated", {
+      action: "translation_config_changed",
+    });
     return Promise.resolve();
+  }
+
+  /** Stable signature of only the config fields that affect the coordinator's behavior. Two configs
+   *  with the same signature produce equivalent coordinators (same backend, same opts), so the circuit
+   *  breaker state can be safely reused across them. */
+  private configSignature(cfg: Record<string, unknown>): string {
+    return JSON.stringify([
+      readString(cfg, "libretranslateUrl", "http://localhost:7001"),
+      readOptionalString(cfg, "libretranslateApiKey") ?? "",
+      readNumber(cfg, "timeoutMs", 4000),
+      readString(cfg, "commandPrefix", "/tr"),
+      readNumber(cfg, "minLength", 2),
+      readNumber(cfg, "maxLength", 2000),
+      readBool(cfg, "denyReply", false),
+    ]);
   }
 
   private buildCoordinator(context: PluginContext): TranslationCoordinator {
@@ -57,19 +110,19 @@ export class TranslationPlugin implements IPlugin {
       warn: (m, meta) => context.logger.warn(m, meta),
     };
     const translator = new LibreTranslateClient({
-      url: readString(cfg, 'libretranslateUrl', 'http://localhost:7001'),
-      apiKey: readOptionalString(cfg, 'libretranslateApiKey'),
-      timeoutMs: readNumber(cfg, 'timeoutMs', 4000),
+      url: readString(cfg, "libretranslateUrl", "http://localhost:7001"),
+      apiKey: readOptionalString(cfg, "libretranslateApiKey"),
+      timeoutMs: readNumber(cfg, "timeoutMs", 4000),
       net: context.net,
       logger,
     });
     const store = new PluginConfigStore(context.storage);
     const gateway = new PluginChatGateway(context.messages, context.engine);
     const opts: CoordinatorOptions = {
-      prefix: readString(cfg, 'commandPrefix', '/tr'),
-      minLength: readNumber(cfg, 'minLength', 2),
-      maxLength: readNumber(cfg, 'maxLength', 2000),
-      denyReply: readBool(cfg, 'denyReply', false),
+      prefix: readString(cfg, "commandPrefix", "/tr"),
+      minLength: readNumber(cfg, "minLength", 2),
+      maxLength: readNumber(cfg, "maxLength", 2000),
+      denyReply: readBool(cfg, "denyReply", false),
     };
     return new TranslationCoordinator(translator, store, gateway, opts, logger);
   }
@@ -77,34 +130,53 @@ export class TranslationPlugin implements IPlugin {
   onDisable(context: PluginContext): Promise<void> {
     // The loader unregisters this plugin's hooks on disable; drop the coordinator too.
     this.coordinator = null;
-    context.logger.log('Translation plugin disabled', { action: 'translation_disabled' });
+    context.logger.log("Translation plugin disabled", {
+      action: "translation_disabled",
+    });
     return Promise.resolve();
   }
 
-  private async onMessage(context: PluginContext, ctx: HookContext<IncomingMessage>): Promise<HookResult> {
+  private async onMessage(
+    context: PluginContext,
+    ctx: HookContext<IncomingMessage>,
+  ): Promise<HookResult> {
     const msg = ctx.data;
     // Only act on engine-originated inbound messages for a known session. The bot's own sends are
     // `fromMe` and route through `message:sent`, so they never reach here (no translation loop).
-    if (!this.coordinator || ctx.source !== 'Engine' || !ctx.sessionId) {
+    if (ctx.source !== "Engine" || !ctx.sessionId) {
       return { continue: true };
     }
+    // Re-check the config signature against the firing session's resolved config — if a per-session
+    // override changed a coordinator-affecting field, rebuild now. Cheap (a JSON.stringify of a handful
+    // of primitives) and runs only the equality check on the hot path; the rebuild is rare. The swap is
+    // not locked, but a translation call is short-lived (bounded by timeoutMs), so an in-flight call on
+    // the old coordinator resolves independently; the new one serves subsequent messages.
+    const sig = this.configSignature(context.config);
+    if (sig !== this.coordinatorSignature || !this.coordinator) {
+      this.coordinator = this.buildCoordinator(context);
+      this.coordinatorSignature = sig;
+    }
+    if (!this.coordinator) return { continue: true };
     try {
       const inbound: InboundMessage = {
         id: msg.id,
         chatId: msg.chatId,
         body: msg.body,
-        author: msg.author ?? '',
+        author: msg.author ?? "",
         isGroup: msg.isGroup,
         fromMe: msg.fromMe,
         mentionedIds: msg.mentionedIds ?? [],
         pushName: msg.contact?.pushName,
       };
-      const { swallow } = await this.coordinator.handleMessage(ctx.sessionId, inbound);
+      const { swallow } = await this.coordinator.handleMessage(
+        ctx.sessionId,
+        inbound,
+      );
       return { continue: !swallow };
     } catch (error) {
-      context.logger.error('Translation hook failed', error, {
+      context.logger.error("Translation hook failed", error, {
         sessionId: ctx.sessionId,
-        action: 'translation_hook_error',
+        action: "translation_hook_error",
       });
       return { continue: true };
     }

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -8,6 +8,15 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Changed
+
+- **Documented that per-session spreadsheet routing is not supported.** The plugin holds one buffer and
+  one Sheets client built from the base `*` config, so a per-session config override that points at a
+  different `spreadsheetId` / `serviceAccountJson` is **not** honored — rows from every session land in
+  the single configured sheet. This is a deliberate single-sink design (the buffer cannot attribute a
+  row to a session at flush time), documented now in the README's **Compatibility** section rather than
+  left implicit. Per-session logging remains a roadmap item if a multi-sink need arises.
+
 ## [0.2.3] — 2026-07-02
 
 ### Fixed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -209,6 +209,18 @@ version-dependent:
   v0.6.0/v0.6.1, a config change needs a disable + re-enable, and a non-graceful exit (SIGKILL/OOM) can
   drop rows buffered since the last flush (≤ `flushIntervalSec`).
 
+### Per-session spreadsheet routing is not supported
+
+The plugin holds a **single** in-memory buffer and a single Sheets client built from the base `*` config
+at `onEnable`. Rows from **every** WhatsApp session land in that one configured sheet. A per-session
+config override that points at a different `spreadsheetId` / `serviceAccountJson` is **not** honored — the
+buffer cannot attribute a row to a session at flush time, so routing per session is a design-level change,
+not a config one.
+
+If you need to log different sessions to different sheets, run **one plugin instance per session** (bind
+each to a single WhatsApp session via the dashboard's session scope), or run multiple OpenWA instances.
+Per-session multi-sink logging is a roadmap item if a concrete need emerges.
+
 ## Security
 
 Message content is treated as untrusted. Writes use `valueInputOption=RAW`, so Google Sheets never

--- a/plugins.json
+++ b/plugins.json
@@ -1084,7 +1084,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -1102,11 +1102,11 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.8.1",
-    "releasedAt": "2026-07-02",
+    "releasedAt": "2026-07-18",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.0.1/voice-transcription.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.0.2/voice-transcription.zip",
     "i18n": {
       "es": {
         "name": "Transcripción de Notas de Voz",

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-07-18
+
+### Fixed
+
+- **Declared the `messages:send` permission required by in-chat delivery.** The `chatDelivery` feature
+  (`self` / `reply`) sends the transcript back into WhatsApp via `ctx.messages.sendText` / `ctx.messages.reply`,
+  both gated by the `messages:send` permission, but the manifest only declared `net:fetch`. As a result,
+  enabling `chatDelivery: 'self'` or `'reply'` threw `PluginCapabilityError` on every transcript send (the
+  default `'off'` masked it). The permission is now declared, so in-chat delivery works as documented.
+
+- **Per-session config overrides are now honored at message time without resetting the circuit breaker
+  on every message.** The coordinator was built once at `onEnable` and the hook read that cached instance,
+  so a per-session override (e.g. a different STT backend or delivery webhook for one session) set via the
+  dashboard after enable was ignored. The hook now recomputes a signature of the coordinator-affecting
+  config fields per event and rebuilds the coordinator only when that signature changes — so an override
+  takes effect, while the STT provider's circuit-breaker state is preserved across messages for an
+  unchanged backend (a naive per-event rebuild would open/close the backend anew on each call and defeat
+  the breaker's purpose).
+  enabling `chatDelivery: 'self'` or `'reply'` threw `PluginCapabilityError` on every transcript send (the
+  default `'off'` masked it). The permission is now declared, so in-chat delivery works as documented.
+
 ## [1.0.1] — 2026-07-02
 
 ### Fixed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -13,8 +13,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.0.1 |
-| **Released** | 2026-07-02 |
+| **Version** | 1.0.2 |
+| **Released** | 2026-07-18 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/voice-transcription/index.test.ts
+++ b/voice-transcription/index.test.ts
@@ -1,20 +1,30 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import type { PluginContext, HookContext, HookResult, IncomingMessage, PluginNetResponse } from '../types/openwa';
-import { VoiceTranscriptionPlugin } from './index.ts';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type {
+  PluginContext,
+  HookContext,
+  HookResult,
+  IncomingMessage,
+  PluginNetResponse,
+} from "../types/openwa";
+import { VoiceTranscriptionPlugin } from "./index.ts";
 
 function voiceMsg(): IncomingMessage {
   return {
-    id: 'm1',
-    from: 'x@s.whatsapp.net',
-    to: 'y@s.whatsapp.net',
-    chatId: 'c1@s.whatsapp.net',
-    body: '',
-    type: 'voice',
+    id: "m1",
+    from: "x@s.whatsapp.net",
+    to: "y@s.whatsapp.net",
+    chatId: "c1@s.whatsapp.net",
+    body: "",
+    type: "voice",
     timestamp: 0,
     fromMe: false,
     isGroup: false,
-    media: { mimetype: 'audio/ogg; codecs=opus', data: Buffer.from('AUDIO').toString('base64'), sizeBytes: 5 },
+    media: {
+      mimetype: "audio/ogg; codecs=opus",
+      data: Buffer.from("AUDIO").toString("base64"),
+      sizeBytes: 5,
+    },
   };
 }
 
@@ -28,16 +38,28 @@ function makeStorage() {
   };
 }
 
-function fakeContext(opts: { net: { fetch: (...a: unknown[]) => Promise<PluginNetResponse> }; config?: Record<string, unknown> }) {
-  let hook: ((ctx: HookContext<IncomingMessage>) => Promise<HookResult>) | undefined;
+function fakeContext(opts: {
+  net: { fetch: (...a: unknown[]) => Promise<PluginNetResponse> };
+  config?: Record<string, unknown>;
+}) {
+  let hook:
+    | ((ctx: HookContext<IncomingMessage>) => Promise<HookResult>)
+    | undefined;
   const ctx = {
-    pluginId: 'voice-transcription',
-    manifest: { id: 'voice-transcription' },
-    config: { sttBaseUrl: 'http://stt', deliveryWebhookUrl: 'http://hook.local/in', ...opts.config },
+    pluginId: "voice-transcription",
+    manifest: { id: "voice-transcription" },
+    config: {
+      sttBaseUrl: "http://stt",
+      deliveryWebhookUrl: "http://hook.local/in",
+      ...opts.config,
+    },
     logger: { log() {}, debug() {}, warn() {}, error() {} },
     storage: makeStorage(),
-    registerHook: (event: string, handler: (c: HookContext<IncomingMessage>) => Promise<HookResult>) => {
-      if (event === 'message:received') hook = handler;
+    registerHook: (
+      event: string,
+      handler: (c: HookContext<IncomingMessage>) => Promise<HookResult>,
+    ) => {
+      if (event === "message:received") hook = handler;
     },
     messages: {},
     engine: {},
@@ -48,44 +70,128 @@ function fakeContext(opts: { net: { fetch: (...a: unknown[]) => Promise<PluginNe
 }
 
 const engineCtx = (data: IncomingMessage): HookContext<IncomingMessage> => ({
-  event: 'message:received',
-  source: 'Engine',
-  sessionId: 's1',
+  event: "message:received",
+  source: "Engine",
+  sessionId: "s1",
   timestamp: new Date(0),
   data,
 });
 
-test('the message:received hook returns {continue:true} without awaiting STT (non-blocking)', async () => {
+test("the message:received hook returns {continue:true} without awaiting STT (non-blocking)", async () => {
   // ctx.net.fetch never resolves. If the hook awaited the STT round-trip, the call below would hang.
   const net = { fetch: () => new Promise<PluginNetResponse>(() => {}) };
   const { ctx, getHook } = fakeContext({ net });
   const plugin = new VoiceTranscriptionPlugin();
   await plugin.onEnable(ctx);
   const hook = getHook();
-  assert.ok(hook, 'plugin must register a message:received hook');
+  assert.ok(hook, "plugin must register a message:received hook");
 
   const hookCall = hook(engineCtx(voiceMsg()));
   const winner = await Promise.race([
-    hookCall.then(r => ({ result: r })),
-    new Promise<string>(res => setTimeout(() => res('timeout'), 250)),
+    hookCall.then((r) => ({ result: r })),
+    new Promise<string>((res) => setTimeout(() => res("timeout"), 250)),
   ]);
-  assert.notEqual(winner, 'timeout', 'hook blocked on STT instead of returning immediately');
-  assert.deepEqual((winner as { result: HookResult }).result, { continue: true });
+  assert.notEqual(
+    winner,
+    "timeout",
+    "hook blocked on STT instead of returning immediately",
+  );
+  assert.deepEqual((winner as { result: HookResult }).result, {
+    continue: true,
+  });
 });
 
-test('does not start transcription for non-Engine sources', async () => {
+test("does not start transcription for non-Engine sources", async () => {
   let fetched = false;
   const net = {
     fetch: async () => {
       fetched = true;
-      return { ok: true, status: 200, statusText: '', headers: {}, body: '{"text":"x"}' } as PluginNetResponse;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "",
+        headers: {},
+        body: '{"text":"x"}',
+      } as PluginNetResponse;
     },
   };
   const { ctx, getHook } = fakeContext({ net });
   const plugin = new VoiceTranscriptionPlugin();
   await plugin.onEnable(ctx);
-  const result = await getHook()!({ ...engineCtx(voiceMsg()), source: 'Dashboard' });
+  const result = await getHook()!({
+    ...engineCtx(voiceMsg()),
+    source: "Dashboard",
+  });
   assert.deepEqual(result, { continue: true });
-  await new Promise(r => setImmediate(r)); // let any floated work run a tick
+  await new Promise((r) => setImmediate(r)); // let any floated work run a tick
   assert.equal(fetched, false);
+});
+
+// Regression: the message hook must rebuild the coordinator when a coordinator-affecting config field
+// changes (per-session override), and must NOT rebuild it when the config is unchanged (preserving the
+// STT provider's circuit-breaker state across messages for the same backend).
+test("coordinator rebuilds when coordinator-affecting config changes, is reused when unchanged", async () => {
+  // Hold config by reference (fakeContext spreads it into a new object, hiding mutations). A custom
+  // context mirrors what the host does: ctx.config is a live view of the firing session's resolved slice.
+  const config: Record<string, unknown> = {
+    sttBaseUrl: "http://stt-a",
+    deliveryWebhookUrl: "http://hook.local/in",
+  };
+  let hook:
+    | ((ctx: HookContext<IncomingMessage>) => Promise<HookResult>)
+    | undefined;
+  const net = {
+    fetch: async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "",
+        headers: {},
+        body: '{"text":"x"}',
+      }) as PluginNetResponse,
+  };
+  const ctx = {
+    pluginId: "voice-transcription",
+    manifest: { id: "voice-transcription" },
+    config, // held by reference — mutations are visible to configSignature on the next hook fire
+    logger: { log() {}, debug() {}, warn() {}, error() {} },
+    storage: makeStorage(),
+    registerHook: (
+      _event: string,
+      handler: (c: HookContext<IncomingMessage>) => Promise<HookResult>,
+    ) => {
+      hook = handler;
+    },
+    messages: {},
+    engine: {},
+    net,
+    hookManager: {},
+  } as unknown as PluginContext;
+  const plugin = new VoiceTranscriptionPlugin();
+  await plugin.onEnable(ctx);
+  assert.ok(hook, "hook registered");
+  const coordAfterEnable = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.ok(coordAfterEnable, "coordinator built at enable");
+
+  // Fire a hook WITHOUT changing config → coordinator must be reused (circuit breaker preserved).
+  hook!(engineCtx(voiceMsg()));
+  const coordUnchanged = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.strictEqual(
+    coordUnchanged,
+    coordAfterEnable,
+    "coordinator reused for unchanged config",
+  );
+
+  // Change a coordinator-affecting field (sttBaseUrl) → coordinator must rebuild on next hook fire.
+  config.sttBaseUrl = "http://stt-b";
+  hook!(engineCtx(voiceMsg()));
+  const coordRebuilt = (plugin as unknown as { coordinator: unknown })
+    .coordinator;
+  assert.notStrictEqual(
+    coordRebuilt,
+    coordAfterEnable,
+    "coordinator rebuilt for changed config",
+  );
 });

--- a/voice-transcription/index.ts
+++ b/voice-transcription/index.ts
@@ -8,84 +8,154 @@
  * webhook — never echoed back into the contact's chat. Disabled until enabled via
  * `POST /plugins/voice-transcription/enable`.
  */
-import type { PluginContext, IPlugin, HookContext, HookResult, IncomingMessage } from '../types/openwa';
-import { OpenAiSttClient } from './openai-stt.client.ts';
-import { WebhookDelivery } from './webhook.delivery.ts';
-import { TranscriptionCoordinator, KvStore, ChatDeliveryMode } from './transcription.coordinator.ts';
+import type {
+  PluginContext,
+  IPlugin,
+  HookContext,
+  HookResult,
+  IncomingMessage,
+} from "../types/openwa";
+import { OpenAiSttClient } from "./openai-stt.client.ts";
+import { WebhookDelivery } from "./webhook.delivery.ts";
+import {
+  TranscriptionCoordinator,
+  KvStore,
+  ChatDeliveryMode,
+} from "./transcription.coordinator.ts";
 
-function readString(cfg: Record<string, unknown>, key: string, fallback: string): string {
+function readString(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: string,
+): string {
   const v = cfg[key];
-  return typeof v === 'string' && v.length > 0 ? v : fallback;
+  return typeof v === "string" && v.length > 0 ? v : fallback;
 }
-function readOptionalString(cfg: Record<string, unknown>, key: string): string | undefined {
+function readOptionalString(
+  cfg: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const v = cfg[key];
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
+  return typeof v === "string" && v.length > 0 ? v : undefined;
 }
-function readNumber(cfg: Record<string, unknown>, key: string, fallback: number): number {
+function readNumber(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
   const v = cfg[key];
-  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
 }
-function readStringArray(cfg: Record<string, unknown>, key: string, fallback: string[]): string[] {
+function readStringArray(
+  cfg: Record<string, unknown>,
+  key: string,
+  fallback: string[],
+): string[] {
   const v = cfg[key];
-  return Array.isArray(v) && v.every(x => typeof x === 'string') && v.length > 0 ? (v as string[]) : fallback;
+  return Array.isArray(v) &&
+    v.every((x) => typeof x === "string") &&
+    v.length > 0
+    ? (v as string[])
+    : fallback;
 }
 function readChatDelivery(cfg: Record<string, unknown>): ChatDeliveryMode {
-  const v = cfg['chatDelivery'];
-  return v === 'self' || v === 'reply' ? v : 'off';
+  const v = cfg["chatDelivery"];
+  return v === "self" || v === "reply" ? v : "off";
 }
 
 export class VoiceTranscriptionPlugin implements IPlugin {
   private coordinator: TranscriptionCoordinator | null = null;
+  private ctxRef: PluginContext | null = null;
+  // Signature of the coordinator-affecting config last used to build `this.coordinator`. The hook
+  // recomputes this per event and rebuilds the coordinator only when it changes — so a per-session
+  // override (resolved by the host for the firing session) takes effect, WITHOUT resetting the STT
+  // provider's circuit breaker on every message (a per-event rebuild would open/close the backend anew
+  // on each call and defeat the breaker's purpose).
+  private coordinatorSignature = "";
 
   onEnable(context: PluginContext): Promise<void> {
+    this.ctxRef = context;
     this.coordinator = this.build(context);
-    context.registerHook('message:received', ctx =>
+    this.coordinatorSignature = this.configSignature(context.config);
+    context.registerHook("message:received", (ctx) =>
       Promise.resolve(this.onMessage(ctx as HookContext<IncomingMessage>)),
     );
-    if (!readOptionalString(context.config, 'deliveryWebhookUrl') && readChatDelivery(context.config) === 'off') {
+    if (
+      !readOptionalString(context.config, "deliveryWebhookUrl") &&
+      readChatDelivery(context.config) === "off"
+    ) {
       context.logger.warn(
-        'voice-transcription: no delivery configured — set deliveryWebhookUrl or chatDelivery, else transcripts have nowhere to go',
-        { action: 'transcription_no_delivery' },
+        "voice-transcription: no delivery configured — set deliveryWebhookUrl or chatDelivery, else transcripts have nowhere to go",
+        { action: "transcription_no_delivery" },
       );
     }
-    context.logger.log('Voice transcription plugin enabled', { action: 'transcription_enabled' });
+    context.logger.log("Voice transcription plugin enabled", {
+      action: "transcription_enabled",
+    });
     return Promise.resolve();
   }
 
   onConfigChange(context: PluginContext): Promise<void> {
+    this.ctxRef = context;
     // Rebuild so an edited config (new STT URL/key, delivery URL) applies without a disable/enable cycle.
     this.coordinator = this.build(context);
-    context.logger.log('Voice transcription config updated', { action: 'transcription_config_changed' });
+    this.coordinatorSignature = this.configSignature(context.config);
+    context.logger.log("Voice transcription config updated", {
+      action: "transcription_config_changed",
+    });
     return Promise.resolve();
+  }
+
+  /** Stable signature of only the config fields that affect the coordinator's behavior. Two configs
+   *  with the same signature produce equivalent coordinators (same backend, same delivery, same guards),
+   *  so the STT provider's circuit breaker state can be safely reused across them. */
+  private configSignature(cfg: Record<string, unknown>): string {
+    return JSON.stringify([
+      readString(cfg, "sttBaseUrl", ""),
+      readOptionalString(cfg, "sttApiKey") ?? "",
+      readString(cfg, "model", "small"),
+      readOptionalString(cfg, "language") ?? "",
+      readNumber(cfg, "timeoutMs", 20000),
+      readString(cfg, "deliveryWebhookUrl", ""),
+      readOptionalString(cfg, "deliverySecret") ?? "",
+      readNumber(cfg, "deliveryTimeoutMs", 5000),
+      readChatDelivery(cfg),
+      JSON.stringify(readStringArray(cfg, "enabledMessageTypes", ["voice"])),
+      readNumber(cfg, "maxSizeBytes", 16 * 1024 * 1024),
+      readNumber(cfg, "maxPerHour", 60),
+      readString(cfg, "provider", "faster-whisper"),
+    ]);
   }
 
   onDisable(context: PluginContext): Promise<void> {
     this.coordinator = null;
-    context.logger.log('Voice transcription plugin disabled', { action: 'transcription_disabled' });
+    context.logger.log("Voice transcription plugin disabled", {
+      action: "transcription_disabled",
+    });
     return Promise.resolve();
   }
 
   private build(context: PluginContext): TranscriptionCoordinator {
     const cfg = context.config;
     const provider = new OpenAiSttClient({
-      baseUrl: readString(cfg, 'sttBaseUrl', ''),
-      apiKey: readOptionalString(cfg, 'sttApiKey'),
-      model: readString(cfg, 'model', 'small'),
-      language: readOptionalString(cfg, 'language'),
-      timeoutMs: readNumber(cfg, 'timeoutMs', 20000),
+      baseUrl: readString(cfg, "sttBaseUrl", ""),
+      apiKey: readOptionalString(cfg, "sttApiKey"),
+      model: readString(cfg, "model", "small"),
+      language: readOptionalString(cfg, "language"),
+      timeoutMs: readNumber(cfg, "timeoutMs", 20000),
       net: context.net,
     });
-    const deliveryUrl = readString(cfg, 'deliveryWebhookUrl', '');
+    const deliveryUrl = readString(cfg, "deliveryWebhookUrl", "");
     const delivery = deliveryUrl
       ? new WebhookDelivery({
           url: deliveryUrl,
-          secret: readOptionalString(cfg, 'deliverySecret'),
-          timeoutMs: readNumber(cfg, 'deliveryTimeoutMs', 5000),
+          secret: readOptionalString(cfg, "deliverySecret"),
+          timeoutMs: readNumber(cfg, "deliveryTimeoutMs", 5000),
           net: context.net,
         })
       : undefined;
     const store: KvStore = {
-      get: key => context.storage.get(key),
+      get: (key) => context.storage.get(key),
       set: (key, value) => context.storage.set(key, value),
     };
     return new TranscriptionCoordinator({
@@ -95,12 +165,14 @@ export class VoiceTranscriptionPlugin implements IPlugin {
       chatDelivery: readChatDelivery(cfg),
       store,
       config: {
-        enabledMessageTypes: readStringArray(cfg, 'enabledMessageTypes', ['voice']),
-        maxSizeBytes: readNumber(cfg, 'maxSizeBytes', 16 * 1024 * 1024),
-        maxPerHour: readNumber(cfg, 'maxPerHour', 60),
+        enabledMessageTypes: readStringArray(cfg, "enabledMessageTypes", [
+          "voice",
+        ]),
+        maxSizeBytes: readNumber(cfg, "maxSizeBytes", 16 * 1024 * 1024),
+        maxPerHour: readNumber(cfg, "maxPerHour", 60),
       },
-      providerLabel: readString(cfg, 'provider', 'faster-whisper'),
-      model: readString(cfg, 'model', 'small'),
+      providerLabel: readString(cfg, "provider", "faster-whisper"),
+      model: readString(cfg, "model", "small"),
       logger: { warn: (m, meta) => context.logger.warn(m, meta) },
     });
   }
@@ -110,8 +182,23 @@ export class VoiceTranscriptionPlugin implements IPlugin {
    * critical path. The coordinator is fail-open, so the floated promise needs no rejection handling.
    */
   private onMessage(ctx: HookContext<IncomingMessage>): HookResult {
-    if (this.coordinator && ctx.source === 'Engine' && ctx.sessionId) {
-      void this.coordinator.handle(ctx.sessionId, ctx.data);
+    if (ctx.source === "Engine" && ctx.sessionId) {
+      // Re-check the config signature against the firing session's resolved config — if a per-session
+      // override changed a coordinator-affecting field, rebuild now. Cheap (a JSON.stringify of a handful
+      // of primitives) and the rebuild is rare. The swap is not locked, but a transcription call runs
+      // off the critical path as an un-awaited promise, so an in-flight call on the old coordinator
+      // resolves independently; the new one serves subsequent messages.
+      const context = this.ctxRef;
+      if (context) {
+        const sig = this.configSignature(context.config);
+        if (sig !== this.coordinatorSignature || !this.coordinator) {
+          this.coordinator = this.build(context);
+          this.coordinatorSignature = sig;
+        }
+      }
+      if (this.coordinator) {
+        void this.coordinator.handle(ctx.sessionId, ctx.data);
+      }
     }
     return { continue: true };
   }

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -9,16 +9,41 @@
   "license": "MIT",
   "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
   "repository": "https://github.com/rmyndharis/OpenWA-plugins",
-  "keywords": ["transcription", "speech-to-text", "stt", "whisper", "voice", "audio", "whatsapp", "openwa"],
+  "keywords": [
+    "transcription",
+    "speech-to-text",
+    "stt",
+    "whisper",
+    "voice",
+    "audio",
+    "whatsapp",
+    "openwa"
+  ],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
   "testedOpenWAVersion": "0.8.1",
-  "provides": ["transcription"],
-  "permissions": ["net:fetch"],
-  "net": { "allow": ["localhost", "127.0.0.1", "api.groq.com:443", "api.openai.com:443"] },
+  "provides": [
+    "transcription"
+  ],
+  "permissions": [
+    "net:fetch",
+    "messages:send"
+  ],
+  "net": {
+    "allow": [
+      "localhost",
+      "127.0.0.1",
+      "api.groq.com:443",
+      "api.openai.com:443"
+    ]
+  },
   "sessionScoped": true,
-  "sessions": ["*"],
-  "hooks": ["message:received"],
+  "sessions": [
+    "*"
+  ],
+  "hooks": [
+    "message:received"
+  ],
   "configSchema": {
     "type": "object",
     "properties": {
@@ -34,30 +59,81 @@
         "secret": true,
         "description": "Bearer key for a hosted backend (Groq/OpenAI). Leave blank for a local Speaches instance."
       },
-      "model": { "type": "string", "title": "Model", "default": "small", "description": "Whisper model name, e.g. small, base, whisper-large-v3-turbo." },
-      "language": { "type": "string", "title": "Language hint", "default": "", "description": "Optional BCP-47 hint (e.g. es). Blank = auto-detect." },
-      "provider": { "type": "string", "title": "Provider label", "default": "faster-whisper", "description": "Informational label recorded in the delivered event." },
-      "timeoutMs": { "type": "number", "title": "STT timeout (ms)", "default": 20000, "min": 1000, "max": 30000, "description": "Per-request STT timeout. Runs off the message-delivery path, so it is bounded only by the host net.fetch ceiling (30000ms), not the 5s hook budget." },
+      "model": {
+        "type": "string",
+        "title": "Model",
+        "default": "small",
+        "description": "Whisper model name, e.g. small, base, whisper-large-v3-turbo."
+      },
+      "language": {
+        "type": "string",
+        "title": "Language hint",
+        "default": "",
+        "description": "Optional BCP-47 hint (e.g. es). Blank = auto-detect."
+      },
+      "provider": {
+        "type": "string",
+        "title": "Provider label",
+        "default": "faster-whisper",
+        "description": "Informational label recorded in the delivered event."
+      },
+      "timeoutMs": {
+        "type": "number",
+        "title": "STT timeout (ms)",
+        "default": 20000,
+        "min": 1000,
+        "max": 30000,
+        "description": "Per-request STT timeout. Runs off the message-delivery path, so it is bounded only by the host net.fetch ceiling (30000ms), not the 5s hook budget."
+      },
       "enabledMessageTypes": {
         "type": "array",
         "title": "Message types to transcribe",
-        "default": ["voice"],
-        "items": { "type": "string" },
+        "default": [
+          "voice"
+        ],
+        "items": {
+          "type": "string"
+        },
         "description": "Usually just voice (PTT). Add audio to also transcribe music/file audio (more cost)."
       },
-      "maxSizeBytes": { "type": "number", "title": "Max audio size (bytes)", "default": 16777216, "description": "Skip audio larger than this (exact cost guard)." },
-      "maxPerHour": { "type": "number", "title": "Max transcriptions / hour / session", "default": 60, "description": "Best-effort per-session hourly cap to bound paid-API spend." },
+      "maxSizeBytes": {
+        "type": "number",
+        "title": "Max audio size (bytes)",
+        "default": 16777216,
+        "description": "Skip audio larger than this (exact cost guard)."
+      },
+      "maxPerHour": {
+        "type": "number",
+        "title": "Max transcriptions / hour / session",
+        "default": 60,
+        "description": "Best-effort per-session hourly cap to bound paid-API spend."
+      },
       "deliveryWebhookUrl": {
         "type": "string",
         "title": "Delivery webhook URL",
         "description": "Your endpoint that receives the message.transcription event (the bot/AI integration channel). Its host MUST be in this plugin's manifest net.allow. Optional if you only use in-chat delivery."
       },
-      "deliverySecret": { "type": "string", "title": "Delivery secret", "secret": true, "description": "Optional. When set, the body is HMAC-SHA256 signed in `X-OpenWA-Signature: sha256=<hex>` (same scheme as OpenWA core webhooks) so your endpoint can verify it." },
-      "deliveryTimeoutMs": { "type": "number", "title": "Delivery timeout (ms)", "default": 5000, "min": 1000, "max": 30000 },
+      "deliverySecret": {
+        "type": "string",
+        "title": "Delivery secret",
+        "secret": true,
+        "description": "Optional. When set, the body is HMAC-SHA256 signed in `X-OpenWA-Signature: sha256=<hex>` (same scheme as OpenWA core webhooks) so your endpoint can verify it."
+      },
+      "deliveryTimeoutMs": {
+        "type": "number",
+        "title": "Delivery timeout (ms)",
+        "default": 5000,
+        "min": 1000,
+        "max": 30000
+      },
       "chatDelivery": {
         "type": "string",
         "title": "In-chat delivery",
-        "enum": ["off", "self", "reply"],
+        "enum": [
+          "off",
+          "self",
+          "reply"
+        ],
         "default": "off",
         "description": "Also post the transcript into WhatsApp: off (webhook only), self (a note to your own number), or reply (quote-reply to the sender — visible to them). Default off."
       }


### PR DESCRIPTION
## Summary

Follow-up to #38 for the two remaining stateful-coordinator plugins (`group-translate`, `voice-transcription`) that had the same per-session config-caching bug, plus a documentation note for `gsheets-logger`.

## Problem

PR #38 fixed `after-hours`, `chat-flow`, and `faq-bot` — three plugins whose hook read a config snapshot cached at `onEnable`, ignoring per-session overrides (the host resolves `ctx.config` per-session inside a hook but returns the base `*` config at lifecycle time).

Two more plugins have the **same bug** but couldn't use the same simple fix: they cache a **stateful coordinator** (not just config values) built from the client that holds a **circuit breaker**. A naive per-event rebuild would reset the breaker on every message, defeating its purpose (a down backend would be hammered on every incoming message instead of being skipped after the threshold).

A third plugin (`gsheets-logger`) has the same caching pattern but is **not fixable without an architecture change**: it holds a single buffer mixing rows from every session, so per-session spreadsheet routing can't work without splitting the buffer by session.

## Changes

### `group-translate` — config-signature caching
- Recompute a `configSignature` (JSON of the coordinator-affecting fields: `libretranslateUrl`, `apiKey`, `timeoutMs`, `commandPrefix`, `minLength`, `maxLength`, `denyReply`) per event.
- Rebuild the coordinator only when the signature changes. An unchanged config reuses the existing coordinator, preserving the LibreTranslate client's circuit breaker across messages.
- A per-session override that changes any of those fields triggers a rebuild on the next hook fire.

### `voice-transcription` — config-signature caching + permission fix
- Same pattern: `configSignature` over `sttBaseUrl`, `apiKey`, `model`, `language`, `timeoutMs`, delivery config, `chatDelivery`, `enabledMessageTypes`, `maxSizeBytes`, `maxPerHour`, `provider`. Rebuild only on signature change.
- **Bundled:** declared `messages:send` in the manifest (v1.0.1 → v1.0.2). The `chatDelivery` feature calls `ctx.messages.sendText`/`reply`, both gated by `messages:send`, but the manifest only declared `net:fetch`. Enabling `chatDelivery: 'self'`/`'reply'` threw `PluginCapabilityError` on every send (default `'off'` masked it).

### `gsheets-logger` — documentation
- README **Compatibility** section now documents that per-session spreadsheet routing is not supported (single buffer + single Sheets client built from base config). Rows from every session land in one configured sheet. Workaround: one instance per session.

### Tests
- `group-translate/index.test.ts` (new): coordinator reused for unchanged config (breaker preserved), rebuilt for changed config (override honored).
- `voice-transcription/index.test.ts`: same two-sided regression test.

## Verification
- `npm run typecheck` — clean
- `npm run catalog:check` — up to date
- `npm test` — **401/401 pass** (was 399; +2 regression tests)