### PR TITLE
fix(types,http-action): align vendored SDK type and http-action floor with core

### DIFF
--- a/http-action/README.md
+++ b/http-action/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.7 (tested null) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested null) |
 | **Keywords** | api, rest, automation, connector, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/http-action](https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action) |
 <!-- END DETAILS -->

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/rmyndharis/OpenWA-plugins",
   "keywords": ["api", "rest", "automation", "connector", "whatsapp", "openwa"],
   "status": "beta",
-  "minOpenWAVersion": "0.8.7",
+  "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
   "provides": ["api-automation", "rest-connector", "dynamic-reply"],
   "permissions": ["net:fetch", "conversation:send"],

--- a/plugins.json
+++ b/plugins.json
@@ -1285,7 +1285,7 @@
       "whatsapp",
       "openwa"
     ],
-    "minOpenWAVersion": "0.8.7",
+    "minOpenWAVersion": "0.8.0",
     "testedOpenWAVersion": null,
     "releasedAt": "2026-07-11",
     "repoPath": "http-action",

--- a/types/openwa.d.ts
+++ b/types/openwa.d.ts
@@ -11,8 +11,9 @@
 export type HookEvent =
   | 'session:created' | 'session:starting' | 'session:ready' | 'session:qr'
   | 'session:disconnected' | 'session:error' | 'session:deleted'
-  | 'message:received' | 'message:sending' | 'message:sent' | 'message:failed' | 'message:ack'
-  | 'webhook:before' | 'webhook:queued' | 'webhook:delivered' | 'webhook:after' | 'webhook:error';
+  | 'message:received' | 'message:sending' | 'message:sent' | 'message:failed' | 'message:ack' | 'message:persisted'
+  | 'webhook:before' | 'webhook:queued' | 'webhook:delivered' | 'webhook:after' | 'webhook:error'
+  | 'ingress:error';
 
 export interface HookContext<T = unknown> {
   event: HookEvent;


### PR DESCRIPTION
## Summary

Two low-severity contract-drift fixes against core `0.10.10`.

## Changes

### `types/openwa.d.ts` — add the two missing HookEvents
The vendored plugin SDK type omitted `message:persisted` and `ingress:error`, both of which core dispatches (19 events total). A plugin that wrote `ctx.registerHook('message:persisted', …)` against this type got a TypeScript error even though the host accepts and dispatches it — the runtime allowed what the type forbade. The type now mirrors core's `HookEvent` union.

### `http-action/manifest.json` — `minOpenWAVersion` 0.8.7 → 0.8.0
The two capabilities http-action relies on — `conversation:send` and `net.allowConfigHosts` — both shipped in 0.8.0 (the Integration Fabric release, per core CHANGELOG). The 0.8.7 floor was overstated by seven patch versions, refusing an install on servers that would in fact run the plugin correctly. Widening compatibility, not a behaviour change — no version bump.

### Regenerated artifacts
`plugins.json` and `http-action/README.md` regenerated by `npm run catalog` so the catalog and the manifest stay in sync (the `catalog:check` CI gate).

## Verification

- `npm run typecheck` clean.
- `npm run catalog:check` — "Catalog up to date".
- `npm test` — 435/435 pass.

## Notes

- The durable fix for the SDK type is to generate it from core's `hook.interfaces.ts` at release time; this PR removes the drift today.
- `http-action` is `beta` with no `testedOpenWAVersion`, so widening the floor is low-risk — operators on 0.8.0+ who were previously refused can now install.