### PR TITLE
release(http-action): 0.1.1

### DIFF
--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to HTTP Action Bot are listed here. Versions follow [Semantic Versioning](https://semver.org/),
 and the top entry's version must match `manifest.json`.
 
+## [0.1.1] — 2026-07-27
+
+### Fixed
+- **`minOpenWAVersion` corrected from 0.8.7 to 0.8.0.** Both capabilities http-action relies on — `conversation:send` and `net.allowConfigHosts` — shipped in OpenWA 0.8.0 (the Integration Fabric release). The 0.8.7 floor was overstated and refused an install on servers that would in fact run the plugin correctly.
+
 ## [0.1.0] — 2026-07-11
 
 ### Added

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.1.0 |
-| **Released** | 2026-07-11 |
+| **Version** | 0.1.1 |
+| **Released** | 2026-07-27 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -9,49 +9,330 @@
   "license": "MIT",
   "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
   "repository": "https://github.com/rmyndharis/OpenWA-plugins",
-  "keywords": ["api", "rest", "automation", "connector", "whatsapp", "openwa"],
+  "keywords": [
+    "api",
+    "rest",
+    "automation",
+    "connector",
+    "whatsapp",
+    "openwa"
+  ],
   "status": "beta",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
-  "provides": ["api-automation", "rest-connector", "dynamic-reply"],
-  "permissions": ["net:fetch", "conversation:send"],
-  "net": { "allow": [], "allowConfigHosts": ["baseUrl"] },
+  "provides": [
+    "api-automation",
+    "rest-connector",
+    "dynamic-reply"
+  ],
+  "permissions": [
+    "net:fetch",
+    "conversation:send"
+  ],
+  "net": {
+    "allow": [],
+    "allowConfigHosts": [
+      "baseUrl"
+    ]
+  },
   "sessionScoped": true,
-  "sessions": ["*"],
-  "hooks": ["message:received"],
+  "sessions": [
+    "*"
+  ],
+  "hooks": [
+    "message:received"
+  ],
   "configSchema": {
     "type": "object",
     "properties": {
-      "baseUrl": { "type": "string", "title": "Base URL", "required": true,
-        "description": "HTTPS origin, e.g. https://erp.example.com. Its host is auto-added to the outbound allowlist (allowConfigHosts). Must be non-empty — without it every fetch is silently gated to a no-op." },
-      "authType": { "type": "string", "enum": ["none", "bearer", "apikey"], "default": "none" },
-      "authToken": { "type": "string", "title": "Token / API key", "secret": true,
-        "description": "Bearer token or API key (per authType). Masked ***." },
-      "apiKeyHeader": { "type": "string", "default": "X-API-Key",
-        "description": "Header name to use when authType=apikey." },
-      "respondInGroups": { "type": "boolean", "default": false },
-      "timeoutMs": { "type": "number", "default": 3000, "min": 500 },
-      "cooldownSeconds": { "type": "number", "default": 3, "min": 0 },
-      "actions": { "type": "textarea", "title": "Actions (JSON array)", "required": true,
-        "description": "JSON array of actions. Example: [{\"id\":\"check-order\",\"match\":{\"type\":\"prefix\",\"value\":\"cek-order \"},\"request\":{\"method\":\"GET\",\"path\":\"/orders/{{args.0}}\"},\"replyTemplate\":\"Order {{response.orderId}}: {{response.status}}\"}]. Parsed at config time." }
+      "baseUrl": {
+        "type": "string",
+        "title": "Base URL",
+        "required": true,
+        "description": "HTTPS origin, e.g. https://erp.example.com. Its host is auto-added to the outbound allowlist (allowConfigHosts). Must be non-empty — without it every fetch is silently gated to a no-op."
+      },
+      "authType": {
+        "type": "string",
+        "enum": [
+          "none",
+          "bearer",
+          "apikey"
+        ],
+        "default": "none"
+      },
+      "authToken": {
+        "type": "string",
+        "title": "Token / API key",
+        "secret": true,
+        "description": "Bearer token or API key (per authType). Masked ***."
+      },
+      "apiKeyHeader": {
+        "type": "string",
+        "default": "X-API-Key",
+        "description": "Header name to use when authType=apikey."
+      },
+      "respondInGroups": {
+        "type": "boolean",
+        "default": false
+      },
+      "timeoutMs": {
+        "type": "number",
+        "default": 3000,
+        "min": 500
+      },
+      "cooldownSeconds": {
+        "type": "number",
+        "default": 3,
+        "min": 0
+      },
+      "actions": {
+        "type": "textarea",
+        "title": "Actions (JSON array)",
+        "required": true,
+        "description": "JSON array of actions. Example: [{\"id\":\"check-order\",\"match\":{\"type\":\"prefix\",\"value\":\"cek-order \"},\"request\":{\"method\":\"GET\",\"path\":\"/orders/{{args.0}}\"},\"replyTemplate\":\"Order {{response.orderId}}: {{response.status}}\"}]. Parsed at config time."
+      }
     }
   },
   "i18n": {
-    "es": { "name": "Bot de acciones HTTP", "description": "Ejecuta solicitudes seguras a API REST desde comandos de WhatsApp y muestra las respuestas JSON en el chat.",
-      "config": { "baseUrl": { "title": "URL base" }, "authType": { "title": "Tipo de autenticación" }, "authToken": { "title": "Token / clave de API" }, "apiKeyHeader": { "title": "Encabezado de clave de API" }, "respondInGroups": { "title": "Responder en grupos" }, "timeoutMs": { "title": "Tiempo de espera de la solicitud (ms)" }, "cooldownSeconds": { "title": "Enfriamiento (segundos)" }, "actions": { "title": "Acciones (array JSON)" } } },
-    "fr": { "name": "Bot d'actions HTTP", "description": "Déclenche des requêtes API REST sécurisées depuis des commandes WhatsApp et affiche les réponses JSON dans le chat.",
-      "config": { "baseUrl": { "title": "URL de base" }, "authType": { "title": "Type d'authentification" }, "authToken": { "title": "Jeton / clé API" }, "apiKeyHeader": { "title": "En-tête de clé API" }, "respondInGroups": { "title": "Répondre dans les groupes" }, "timeoutMs": { "title": "Délai d'attente de la requête (ms)" }, "cooldownSeconds": { "title": "Temps de recharge (secondes)" }, "actions": { "title": "Actions (tableau JSON)" } } },
-    "it": { "name": "Bot di azioni HTTP", "description": "Esegue richieste sicure a API REST dai comandi WhatsApp e mostra le risposte JSON nella chat.",
-      "config": { "baseUrl": { "title": "URL di base" }, "authType": { "title": "Tipo di autenticazione" }, "authToken": { "title": "Token / chiave API" }, "apiKeyHeader": { "title": "Header della chiave API" }, "respondInGroups": { "title": "Rispondi nei gruppi" }, "timeoutMs": { "title": "Timeout della richiesta (ms)" }, "cooldownSeconds": { "title": "Tempo di attesa (secondi)" }, "actions": { "title": "Azioni (array JSON)" } } },
-    "ar": { "name": "بوت إجراءات HTTP", "description": "يشغّل طلبات REST API آمنة من أوامر WhatsApp ويعرض استجابات JSON في المحادثة.",
-      "config": { "baseUrl": { "title": "الرابط الأساسي" }, "authType": { "title": "نوع المصادقة" }, "authToken": { "title": "الرمز / مفتاح API" }, "apiKeyHeader": { "title": "ترويسة مفتاح API" }, "respondInGroups": { "title": "الرد في المجموعات" }, "timeoutMs": { "title": "مهلة الطلب (ميلي ثانية)" }, "cooldownSeconds": { "title": "فترة التهدئة (بالثواني)" }, "actions": { "title": "الإجراءات (مصفوفة JSON)" } } },
-    "he": { "name": "בוט פעולות HTTP", "description": "מפעיל בקשות REST API בטוחות מפקודות WhatsApp ומציג תגובות JSON חזרה בצ'אט.",
-      "config": { "baseUrl": { "title": "כתובת בסיס" }, "authType": { "title": "סוג אימות" }, "authToken": { "title": "אסימון / מפתח API" }, "apiKeyHeader": { "title": "כותרת מפתח API" }, "respondInGroups": { "title": "השב בקבוצות" }, "timeoutMs": { "title": "פסק זמן לבקשה (ms)" }, "cooldownSeconds": { "title": "צינון (שניות)" }, "actions": { "title": "פעולות (מערך JSON)" } } },
-    "te": { "name": "HTTP యాక్షన్ బాట్", "description": "WhatsApp కమాండ్‌ల నుండి సురక్షిత REST API అభ్యర్థనలను ట్రిగర్ చేసి, JSON ప్రతిస్పందనలను చాట్‌లో చూపిస్తుంది.",
-      "config": { "baseUrl": { "title": "బేస్ URL" }, "authType": { "title": "ప్రామాణీకరణ రకం" }, "authToken": { "title": "టోకెన్ / API కీ" }, "apiKeyHeader": { "title": "API కీ హెడర్" }, "respondInGroups": { "title": "గ్రూపులలో స్పందించు" }, "timeoutMs": { "title": "అభ్యర్థన గడువు (ms)" }, "cooldownSeconds": { "title": "కూల్‌డౌన్ (సెకన్లు)" }, "actions": { "title": "చర్యలు (JSON శ్రేణి)" } } },
-    "zh-CN": { "name": "HTTP 动作机器人", "description": "从 WhatsApp 命令触发安全的 REST API 请求，并将 JSON 响应展示回聊天中。",
-      "config": { "baseUrl": { "title": "基础 URL" }, "authType": { "title": "认证类型" }, "authToken": { "title": "令牌 / API 密钥" }, "apiKeyHeader": { "title": "API 密钥请求头" }, "respondInGroups": { "title": "在群组中回复" }, "timeoutMs": { "title": "请求超时（毫秒）" }, "cooldownSeconds": { "title": "冷却时间（秒）" }, "actions": { "title": "动作（JSON 数组）" } } },
-    "zh-HK": { "name": "HTTP 動作機器人", "description": "從 WhatsApp 指令觸發安全的 REST API 請求，並將 JSON 回應顯示回對話中。",
-      "config": { "baseUrl": { "title": "基礎 URL" }, "authType": { "title": "認證類型" }, "authToken": { "title": "權杖 / API 金鑰" }, "apiKeyHeader": { "title": "API 金鑰標頭" }, "respondInGroups": { "title": "在群組中回覆" }, "timeoutMs": { "title": "請求逾時（毫秒）" }, "cooldownSeconds": { "title": "冷卻時間（秒）" }, "actions": { "title": "動作（JSON 陣列）" } } }
+    "es": {
+      "name": "Bot de acciones HTTP",
+      "description": "Ejecuta solicitudes seguras a API REST desde comandos de WhatsApp y muestra las respuestas JSON en el chat.",
+      "config": {
+        "baseUrl": {
+          "title": "URL base"
+        },
+        "authType": {
+          "title": "Tipo de autenticación"
+        },
+        "authToken": {
+          "title": "Token / clave de API"
+        },
+        "apiKeyHeader": {
+          "title": "Encabezado de clave de API"
+        },
+        "respondInGroups": {
+          "title": "Responder en grupos"
+        },
+        "timeoutMs": {
+          "title": "Tiempo de espera de la solicitud (ms)"
+        },
+        "cooldownSeconds": {
+          "title": "Enfriamiento (segundos)"
+        },
+        "actions": {
+          "title": "Acciones (array JSON)"
+        }
+      }
+    },
+    "fr": {
+      "name": "Bot d'actions HTTP",
+      "description": "Déclenche des requêtes API REST sécurisées depuis des commandes WhatsApp et affiche les réponses JSON dans le chat.",
+      "config": {
+        "baseUrl": {
+          "title": "URL de base"
+        },
+        "authType": {
+          "title": "Type d'authentification"
+        },
+        "authToken": {
+          "title": "Jeton / clé API"
+        },
+        "apiKeyHeader": {
+          "title": "En-tête de clé API"
+        },
+        "respondInGroups": {
+          "title": "Répondre dans les groupes"
+        },
+        "timeoutMs": {
+          "title": "Délai d'attente de la requête (ms)"
+        },
+        "cooldownSeconds": {
+          "title": "Temps de recharge (secondes)"
+        },
+        "actions": {
+          "title": "Actions (tableau JSON)"
+        }
+      }
+    },
+    "it": {
+      "name": "Bot di azioni HTTP",
+      "description": "Esegue richieste sicure a API REST dai comandi WhatsApp e mostra le risposte JSON nella chat.",
+      "config": {
+        "baseUrl": {
+          "title": "URL di base"
+        },
+        "authType": {
+          "title": "Tipo di autenticazione"
+        },
+        "authToken": {
+          "title": "Token / chiave API"
+        },
+        "apiKeyHeader": {
+          "title": "Header della chiave API"
+        },
+        "respondInGroups": {
+          "title": "Rispondi nei gruppi"
+        },
+        "timeoutMs": {
+          "title": "Timeout della richiesta (ms)"
+        },
+        "cooldownSeconds": {
+          "title": "Tempo di attesa (secondi)"
+        },
+        "actions": {
+          "title": "Azioni (array JSON)"
+        }
+      }
+    },
+    "ar": {
+      "name": "بوت إجراءات HTTP",
+      "description": "يشغّل طلبات REST API آمنة من أوامر WhatsApp ويعرض استجابات JSON في المحادثة.",
+      "config": {
+        "baseUrl": {
+          "title": "الرابط الأساسي"
+        },
+        "authType": {
+          "title": "نوع المصادقة"
+        },
+        "authToken": {
+          "title": "الرمز / مفتاح API"
+        },
+        "apiKeyHeader": {
+          "title": "ترويسة مفتاح API"
+        },
+        "respondInGroups": {
+          "title": "الرد في المجموعات"
+        },
+        "timeoutMs": {
+          "title": "مهلة الطلب (ميلي ثانية)"
+        },
+        "cooldownSeconds": {
+          "title": "فترة التهدئة (بالثواني)"
+        },
+        "actions": {
+          "title": "الإجراءات (مصفوفة JSON)"
+        }
+      }
+    },
+    "he": {
+      "name": "בוט פעולות HTTP",
+      "description": "מפעיל בקשות REST API בטוחות מפקודות WhatsApp ומציג תגובות JSON חזרה בצ'אט.",
+      "config": {
+        "baseUrl": {
+          "title": "כתובת בסיס"
+        },
+        "authType": {
+          "title": "סוג אימות"
+        },
+        "authToken": {
+          "title": "אסימון / מפתח API"
+        },
+        "apiKeyHeader": {
+          "title": "כותרת מפתח API"
+        },
+        "respondInGroups": {
+          "title": "השב בקבוצות"
+        },
+        "timeoutMs": {
+          "title": "פסק זמן לבקשה (ms)"
+        },
+        "cooldownSeconds": {
+          "title": "צינון (שניות)"
+        },
+        "actions": {
+          "title": "פעולות (מערך JSON)"
+        }
+      }
+    },
+    "te": {
+      "name": "HTTP యాక్షన్ బాట్",
+      "description": "WhatsApp కమాండ్‌ల నుండి సురక్షిత REST API అభ్యర్థనలను ట్రిగర్ చేసి, JSON ప్రతిస్పందనలను చాట్‌లో చూపిస్తుంది.",
+      "config": {
+        "baseUrl": {
+          "title": "బేస్ URL"
+        },
+        "authType": {
+          "title": "ప్రామాణీకరణ రకం"
+        },
+        "authToken": {
+          "title": "టోకెన్ / API కీ"
+        },
+        "apiKeyHeader": {
+          "title": "API కీ హెడర్"
+        },
+        "respondInGroups": {
+          "title": "గ్రూపులలో స్పందించు"
+        },
+        "timeoutMs": {
+          "title": "అభ్యర్థన గడువు (ms)"
+        },
+        "cooldownSeconds": {
+          "title": "కూల్‌డౌన్ (సెకన్లు)"
+        },
+        "actions": {
+          "title": "చర్యలు (JSON శ్రేణి)"
+        }
+      }
+    },
+    "zh-CN": {
+      "name": "HTTP 动作机器人",
+      "description": "从 WhatsApp 命令触发安全的 REST API 请求，并将 JSON 响应展示回聊天中。",
+      "config": {
+        "baseUrl": {
+          "title": "基础 URL"
+        },
+        "authType": {
+          "title": "认证类型"
+        },
+        "authToken": {
+          "title": "令牌 / API 密钥"
+        },
+        "apiKeyHeader": {
+          "title": "API 密钥请求头"
+        },
+        "respondInGroups": {
+          "title": "在群组中回复"
+        },
+        "timeoutMs": {
+          "title": "请求超时（毫秒）"
+        },
+        "cooldownSeconds": {
+          "title": "冷却时间（秒）"
+        },
+        "actions": {
+          "title": "动作（JSON 数组）"
+        }
+      }
+    },
+    "zh-HK": {
+      "name": "HTTP 動作機器人",
+      "description": "從 WhatsApp 指令觸發安全的 REST API 請求，並將 JSON 回應顯示回對話中。",
+      "config": {
+        "baseUrl": {
+          "title": "基礎 URL"
+        },
+        "authType": {
+          "title": "認證類型"
+        },
+        "authToken": {
+          "title": "權杖 / API 金鑰"
+        },
+        "apiKeyHeader": {
+          "title": "API 金鑰標頭"
+        },
+        "respondInGroups": {
+          "title": "在群組中回覆"
+        },
+        "timeoutMs": {
+          "title": "請求逾時（毫秒）"
+        },
+        "cooldownSeconds": {
+          "title": "冷卻時間（秒）"
+        },
+        "actions": {
+          "title": "動作（JSON 陣列）"
+        }
+      }
+    }
   }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -1271,7 +1271,7 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "type": "extension",
     "status": "beta",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -1287,11 +1287,11 @@
     ],
     "minOpenWAVersion": "0.8.0",
     "testedOpenWAVersion": null,
-    "releasedAt": "2026-07-11",
+    "releasedAt": "2026-07-27",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.1.0/http-action.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.1.1/http-action.zip",
     "i18n": {
       "es": {
         "name": "Bot de acciones HTTP",


### PR DESCRIPTION
Patch release to ship the corrected `minOpenWAVersion` floor (0.8.7 → 0.8.0) from #48. The v0.1.0 zip on the GitHub Release still carries the old floor; this release updates it. No behaviour change — only the compatibility metadata.