### PR TITLE
fix(catalog): regenerate the root README after the http-action 0.1.1 bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository provides:
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.1.7 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.0.6 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.0 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.1.0 | beta |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.1.1 | beta |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.2.0 | beta |
 | [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.1.0 | beta |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.0.2 | beta |


### PR DESCRIPTION
## Summary

`main` has been failing CI since the http-action 0.1.1 release merged. The failing step is `Catalog up to date (plugins.json, READMEs, version↔changelog)`, which runs `node scripts/catalog.mjs --check`.

The 0.1.1 release updated `http-action/manifest.json`, `http-action/CHANGELOG.md`, `http-action/README.md`, and the `plugins.json` entry, but the catalog table in the root `README.md` was left at `0.1.0`. Since `catalog.mjs` regenerates that table from the manifests and CI compares its output against what is committed, the stale version cell fails the check.

## Change

Regenerated the catalog with `npm run catalog`. `README.md` is the only file that drifted — `plugins.json` was already correct at `0.1.1`.

```
-| [`http-action`](./http-action) | ... | 0.1.0 | beta |
+| [`http-action`](./http-action) | ... | 0.1.1 | beta |
```

## Verification

Confirmed the failure reproduces on the release merge commit in a clean checkout, and that the regenerated output matches this change exactly.

Local run of the CI steps on this branch:

- `npm run typecheck` — passes
- `npm test` — 435 passing, 0 failing
- `npm run catalog:check` — `Catalog up to date (10 plugin(s)).`

## Note

CI was already red on the release PR before it merged. Requiring the `ci` check to pass in branch protection would keep this class of drift from reaching `main`.