### PR TITLE
fix(typebot-connector): make file-upload steps complete, and promote to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository provides:
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.2 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.0 | beta |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | beta |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | stable |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.0 | beta |
 <!-- END PLUGIN CATALOG -->
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository provides:
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.2 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.0 | beta |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.0 | beta |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | beta |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.0 | beta |
 <!-- END PLUGIN CATALOG -->
 

--- a/plugins.json
+++ b/plugins.json
@@ -1713,7 +1713,7 @@
     "name": "Typebot Connector",
     "version": "0.2.1",
     "type": "extension",
-    "status": "beta",
+    "status": "stable",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
     "author": "Yudhi Armyndharis <yudhi@rmyndharis.com>",
     "license": "MIT",

--- a/plugins.json
+++ b/plugins.json
@@ -1711,7 +1711,7 @@
   {
     "id": "typebot-connector",
     "name": "Typebot Connector",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "extension",
     "status": "beta",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -1733,7 +1733,7 @@
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.0/typebot-connector.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.1/typebot-connector.zip",
     "i18n": {
       "es": {
         "name": "Conector de Typebot",

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the Typebot Connector plugin are documented here. The for
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-07-31
+
+### Fixed
+
+- **Uploading a file at a Typebot file-upload step got stuck in a loop.** The photo or document reached
+  storage every time, but the flow answered "Invalid message. Please, try again." and asked for the same
+  file again, indefinitely. A file-upload step expects the uploaded file's URL as the answer itself, while
+  a text step that merely allows an attachment expects the typed answer with the file attached alongside
+  it — the plugin was sending the second shape for both, so a file-upload step never accepted what it was
+  sent. Each is now answered the way it expects, and a file-upload step advances the flow like any other.
+
 ## [0.2.0] — 2026-07-31
 
 ### Fixed

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to the Typebot Connector plugin are documented here. The for
   it — the plugin was sending the second shape for both, so a file-upload step never accepted what it was
   sent. Each is now answered the way it expects, and a file-upload step advances the flow like any other.
 
+### Verified
+
+- **Confirmed fixed against a live self-hosted Typebot install.** On 2026-07-31, a real WhatsApp photo was
+  smoke-tested end-to-end through OpenWA 0.12.1 against a self-hosted Typebot v3.17.2 instance: the upload
+  reached storage and the file-upload step advanced the flow to the next block.
+
 ## [0.2.0] — 2026-07-31
 
 ### Fixed

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -16,7 +16,7 @@
 | **Identifier** | `typebot-connector` |
 | **Version** | 0.2.1 |
 | **Released** | 2026-07-31 |
-| **Status** | beta |
+| **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -14,7 +14,7 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `typebot-connector` |
-| **Version** | 0.2.0 |
+| **Version** | 0.2.1 |
 | **Released** | 2026-07-31 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
   "repository": "https://github.com/rmyndharis/OpenWA-plugins",
   "keywords": ["typebot", "chatbot", "flow", "bot", "no-code", "two-way", "whatsapp", "openwa"],
-  "status": "beta",
+  "status": "stable",
   "minOpenWAVersion": "0.8.2",
   "testedOpenWAVersion": "0.12.1",
   "sdkVersion": "1",

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "typebot-connector",
   "name": "Typebot Connector",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",

--- a/typebot-connector/turn.ts
+++ b/typebot-connector/turn.ts
@@ -55,7 +55,12 @@ export async function handleTurn(deps: TurnDeps, sessionId: string, source: stri
           await send(deps, sessionId, msg, { type: 'text', text: 'Sorry, that upload failed — please try sending the file again.' });
           return; // state stays intact so the user can retry
         }
-        message = { type: 'text', text: '', attachedFileUrls: [url] };
+        // A `file input` block's answer IS the file: Typebot validates message.text as the URL and rejects an
+        // empty text with attachedFileUrls. A text input with attachments enabled is the opposite — there the
+        // answer is the typed text and the file rides along in attachedFileUrls.
+        message = state.awaiting.kind === 'file'
+          ? { type: 'text', text: url }
+          : { type: 'text', text: '', attachedFileUrls: [url] };
       } else {
         message = intent.message;
       }

--- a/typebot-connector/upload-e2e.test.ts
+++ b/typebot-connector/upload-e2e.test.ts
@@ -123,9 +123,11 @@ test('file input, proxy branch: PUT raw bytes, then continueChat carries the ret
   assert.deepEqual(Buffer.from(calls[1].init!.body as Uint8Array), PNG);
 
   // continueChat carries fileUrl from generate-upload-url — NOT presignedUrl, which is single-use.
+  // A `file input` block's answer IS the file: Typebot validates message.text as the URL and rejects an
+  // empty text with attachedFileUrls (verified against a live Typebot v3.17.2 instance).
   assert.equal(calls[2].url, 'https://typebot.io/api/v1/sessions/S1/continueChat');
   const cont = JSON.parse(calls[2].init!.body as string);
-  assert.deepEqual(cont.message, { type: 'text', text: '', attachedFileUrls: ['https://cdn/p.png'] });
+  assert.deepEqual(cont.message, { type: 'text', text: 'https://cdn/p.png' });
 
   // The next prompt reaches WhatsApp and the advanced state is persisted.
   assert.deepEqual(sent.map(s => s.text), ['Got it']);
@@ -174,6 +176,62 @@ test('file input, S3 branch: multipart POST with every policy field before the f
   assert.deepEqual(raw.subarray(start, start + PNG.length), PNG);
 
   const cont = JSON.parse(calls[2].init!.body as string);
-  assert.deepEqual(cont.message, { type: 'text', text: '', attachedFileUrls: ['https://cdn/s3.png'] });
+  assert.deepEqual(cont.message, { type: 'text', text: 'https://cdn/s3.png' });
   assert.deepEqual(sent.map(s => s.text), ['Received']);
+});
+
+// Different construct from a `file input` block: here the flow is a TEXT input with attachments enabled,
+// so the typed text is the answer and the upload rides along in attachedFileUrls. Conflating the two was
+// the root cause of the file-input regression above — this scenario pins the other side of that branch so
+// the two constructs can't be silently swapped again.
+test('text input with attachments enabled: continueChat carries the text plus attachedFileUrls', async () => {
+  const { fetchFn, calls } = recorder([
+    ok({ presignedUrl: 'https://typebot.io/api/uploads/tok', formData: {}, fileUrl: 'https://cdn/p.png' }),
+    noBody(200),
+    ok({
+      sessionId: 'S1',
+      messages: [{ id: 'm2', type: 'text', content: { type: 'markdown', markdown: 'Got it' } }],
+      input: { id: 'blk2', type: 'text input' },
+    }),
+  ]);
+  const sent: ConversationSendEnvelope[] = [];
+  const conversations: PluginConversationsCapability = { send: async e => void sent.push(e) };
+  const store = new SessionStore(fakeStorage());
+  await store.set('sess:c@c.us', {
+    sessionId: 'S1',
+    awaiting: { kind: 'text', blockId: 'blk', attachmentsEnabled: true },
+    lastActivity: 1000,
+  });
+  const msg = {
+    id: 'm',
+    from: 'c@c.us',
+    to: 'me',
+    chatId: 'c@c.us',
+    body: '',
+    type: 'image',
+    timestamp: 0,
+    fromMe: false,
+    isGroup: false,
+    media: { mimetype: 'image/png', filename: 'p.png', data: PNG.toString('base64') },
+  } as IncomingMessage;
+
+  await handleTurn(
+    {
+      cfg,
+      client: new TypebotClient(fetchFn, cfg),
+      store,
+      lock: new KeyedAsyncLock(),
+      conversations,
+      now: () => 1000,
+      log: () => {},
+    },
+    'sess',
+    'Engine',
+    msg,
+  );
+
+  assert.equal(calls[2].url, 'https://typebot.io/api/v1/sessions/S1/continueChat');
+  const cont = JSON.parse(calls[2].init!.body as string);
+  assert.deepEqual(cont.message, { type: 'text', text: '', attachedFileUrls: ['https://cdn/p.png'] });
+  assert.deepEqual(sent.map(s => s.text), ['Got it']);
 });


### PR DESCRIPTION
Fixes a defect that made `typebot-connector`'s file-upload support unusable, then promotes the plugin to `stable` on the strength of a live verification.

## The defect

When a Typebot flow reached a **file-upload block**, the plugin uploaded the contact's photo or document successfully — the bytes reached storage every time — and then the flow never moved on. Typebot answered `Invalid message. Please, try again.` and asked for the same file again, indefinitely. A contact could never complete a flow containing a file step.

The cause is that two different Typebot constructs were being answered the same way:

- A **file-upload block** takes the uploaded file's URL as the answer itself, in the message text.
- A **text input that merely permits an attachment** takes the typed answer, with the file carried alongside in a separate attachments field.

The plugin sent the second form for both, so a file-upload block never accepted what it was given. `turn.ts` now selects the form from the block being answered.

## Why the tests did not catch it

`upload-e2e.test.ts` asserted the attachments form for a file-upload flow and passed, because its fake fetch accepts whatever it is handed — it pinned an assumption about Typebot rather than Typebot's actual behaviour. Both of its assertions are corrected here, and a third case is added covering a text input with attachments enabled, so the two constructs cannot be swapped again without a test failing. Inverting the branch turns all three red.

## Live verification

Run on 2026-07-31 against OpenWA 0.12.1 and a self-hosted Typebot v3.17.2 with MinIO storage, using two connected WhatsApp sessions so a real inbound photo could be driven end to end.

- A real WhatsApp photo — including an `@lid` sender and WhatsApp's own JPEG transcode — reached the plugin with usable media data, was uploaded, and the flow advanced from the file-upload block to the next block.
- The stored object carried the `Cache-Control` header the plugin sets, confirming the upload was performed by the plugin rather than by anything else in the path.
- Reverting the fix while leaving everything else identical reproduced the failure: the flow stayed on the file-upload block.

Scope of that run, stated precisely: Typebot v3.17.2 returns no form data from its upload-URL endpoint, so the same-origin signed-`PUT` branch was exercised. The S3 presigned-`POST` branch, which only older self-hosted installs use, was not reached, and Typebot Cloud was not covered.

## Status

`typebot-connector` moves from `beta` to `stable` at 0.2.1. `testedOpenWAVersion` remains 0.12.1, which is the host the verification ran against. No other plugin changes.
