### PR TITLE
release(http-action): promote 0.2.1 to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository provides:
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.0 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.1.0 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.2 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.0 | beta |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.1 | stable |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
 | [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | stable |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.0 | beta |

--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to HTTP Action Bot are listed here. Versions follow [Semantic Versioning](https://semver.org/),
 and the top entry's version must match `manifest.json`.
 
+## [0.2.1] — 2026-08-01
+
+### Changed
+
+- **Status promoted from `beta` to `stable`.** No behaviour changed in this release. A manual install
+  smoke on a real OpenWA 0.12.1 host — the one check that cannot be automated — has now been run in
+  full and passed: install from package, configure, and enable; a POST command with path and JSON-body
+  templating (reply carried the templated body, the sender's phone number resolved correctly, the
+  configured bearer credential reached the upstream); a command against an upstream 404 (the configured
+  not-found template was used); a command against an upstream 500 (the configured error template was
+  used); disable/re-enable (configuration survived, a command worked afterwards); and a host restart
+  (the plugin came back enabled and a command was confirmed working afterwards). With another
+  responder plugin installed alongside, commands were answered by this plugin and non-command messages
+  went to the other plugin, confirming the co-installation ordering behaves as documented.
+
 ## [0.2.0] — 2026-07-31
 
 ### Fixed

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,9 +14,9 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.2.0 |
-| **Released** | 2026-07-31 |
-| **Status** | beta |
+| **Version** | 0.2.1 |
+| **Released** | 2026-08-01 |
+| **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
@@ -106,11 +106,9 @@ and upload it in the dashboard **Plugins → Install** (or the **Catalog** tab).
 
 ## Compatibility
 
-Status is **beta**. It targets OpenWA **≥ 0.8.0**, the release that introduced both capabilities it
-relies on (`net.allowConfigHosts` and `conversation:send`). `testedOpenWAVersion` is deliberately unset:
-the plugin has not been install- and runtime-tested on a real OpenWA instance, and that field is only
-worth anything if it is honest. Live config edits apply on the next inbound message (config is re-read
-per event).
+Targets OpenWA **≥ 0.8.0**, the release that introduced both capabilities it relies on
+(`net.allowConfigHosts` and `conversation:send`). Live config edits apply on the next inbound message
+(config is re-read per event).
 
 ### Per-session config
 

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -17,7 +17,7 @@
     "whatsapp",
     "openwa"
   ],
-  "status": "beta",
+  "status": "stable",
   "testedOpenWAVersion": "0.12.1",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",

--- a/plugins.json
+++ b/plugins.json
@@ -1271,9 +1271,9 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "extension",
-    "status": "beta",
+    "status": "stable",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
     "author": "Yudhi Armyndharis <yudhi@rmyndharis.com>",
     "license": "MIT",
@@ -1287,11 +1287,11 @@
     ],
     "minOpenWAVersion": "0.8.0",
     "testedOpenWAVersion": "0.12.1",
-    "releasedAt": "2026-07-31",
+    "releasedAt": "2026-08-01",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.0/http-action.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.1/http-action.zip",
     "i18n": {
       "es": {
         "name": "Bot de acciones HTTP",


### PR DESCRIPTION
`http-action` has been held at `beta` on one outstanding item: a manual install smoke on a real host, covering the checks that cannot be automated. That smoke has now been run in full and passed, so the status moves to `stable`. No behaviour changed in this release.

Verified against a live OpenWA 0.12.1 host with a connected WhatsApp session, an HTTP echo service upstream, and commands driven from a second connected number:

- install from package, configure, enable;
- a POST command with path and JSON-body templating — the reply carried the templated body, the sender's phone resolved from the message, and the configured bearer credential reached the upstream;
- a command whose upstream returns 404 — the not-found template was selected;
- a command whose upstream returns 500 — the error template was selected;
- disable and re-enable — configuration survived and a command worked afterwards;
- a host restart — the plugin came back enabled and a command was confirmed working afterwards, not merely reported as enabled.

With another responder plugin installed alongside, commands were answered by this plugin and non-command messages went to the other one, so the co-installation ordering behaves as documented.

`testedOpenWAVersion` is unchanged at 0.12.1. A stale sentence in the plugin README that described the status as beta and the plugin as not install-tested has been removed, since it now contradicts the shipped state.