### PR TITLE
chore(chat-flow,faq-bot,after-hours): record 0.12.1 as the tested host

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ This repository provides:
 <!-- BEGIN PLUGIN CATALOG -->
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
-| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.0 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.0 | stable |
+| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.1 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.1 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.8.0 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.0 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.1 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.1.0 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.2 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.1 | stable |

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,21 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-08-01
+
+No behaviour change. 0.2.0 has now been smoke-tested against a newer host, so the tested-version field
+is updated to match.
+
+### Verified
+
+- **Confirmed against a live OpenWA 0.12.1 host**, with a connected WhatsApp session, this plugin
+  enabled alongside four other responder plugins (including chat-flow and faq-bot) and driven by real
+  messages from a second connected WhatsApp number. A message matching nothing more specific fell
+  through to the other catch-all responder rather than this plugin, as expected from the 0.2.0
+  last-registered priority; with that other catch-all disabled, the same kind of message was then
+  answered by this plugin with its configured away message.
+- **Not covered:** group chats, media messages, and behaviour under load.
+
 ## [0.2.0] — 2026-07-31
 
 ### Fixed

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -13,13 +13,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `after-hours` |
-| **Version** | 0.2.0 |
-| **Released** | 2026-07-31 |
+| **Version** | 0.2.1 |
+| **Released** | 2026-08-01 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "after-hours",
   "name": "After-Hours Auto-Reply",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.8.1",
+  "testedOpenWAVersion": "0.12.1",
   "provides": [
     "auto-reply"
   ],

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,21 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-08-01
+
+No behaviour change. 1.1.0 has now been smoke-tested against a newer host, so the tested-version field
+is updated to match.
+
+### Verified
+
+- **Confirmed against a live OpenWA 0.12.1 host**, with a connected WhatsApp session, this plugin
+  enabled alongside four other responder plugins (including faq-bot and after-hours) and driven by real
+  messages from a second connected WhatsApp number. A message matching the configured trigger word
+  started the menu flow, answered by this plugin and by nothing else — and once the contact was inside
+  the menu, this plugin continued to own their replies until the flow was cleared, confirming the 1.1.0
+  responder-priority fix holds with a full set of co-installed responders.
+- **Not covered:** group chats, media messages, and behaviour under load.
+
 ## [1.1.0] — 2026-07-31
 
 ### Fixed

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.1.0 |
-| **Released** | 2026-07-31 |
+| **Version** | 1.1.1 |
+| **Released** | 2026-08-01 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.8.1",
+  "testedOpenWAVersion": "0.12.1",
   "provides": [
     "auto-reply"
   ],

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,20 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-08-01
+
+No behaviour change. 0.2.0 has now been smoke-tested against a newer host, so the tested-version field
+is updated to match.
+
+### Verified
+
+- **Confirmed against a live OpenWA 0.12.1 host**, with a connected WhatsApp session, this plugin
+  enabled alongside four other responder plugins (including chat-flow and after-hours) and driven by
+  real messages from a second connected WhatsApp number. A message matching a configured keyword rule
+  was answered by this plugin and by nothing else, confirming the 0.2.0 message-claiming and
+  responder-priority fixes hold with a full set of co-installed responders.
+- **Not covered:** group chats, media messages, and behaviour under load.
+
 ## [0.2.0] — 2026-07-31
 
 ### Fixed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.0 |
-| **Released** | 2026-07-31 |
+| **Version** | 0.2.1 |
+| **Released** | 2026-08-01 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.8.1) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.12.1) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.8.1",
+  "testedOpenWAVersion": "0.12.1",
   "provides": [
     "auto-reply"
   ],

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "after-hours",
     "name": "After-Hours Auto-Reply",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -17,12 +17,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.8.1",
-    "releasedAt": "2026-07-31",
+    "testedOpenWAVersion": "0.12.1",
+    "releasedAt": "2026-08-01",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.0/after-hours.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.1/after-hours.zip",
     "i18n": {
       "es": {
         "name": "Respuesta Automática Fuera de Horario",
@@ -197,7 +197,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -213,12 +213,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.8.1",
-    "releasedAt": "2026-07-31",
+    "testedOpenWAVersion": "0.12.1",
+    "releasedAt": "2026-08-01",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.0/chat-flow.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.1/chat-flow.zip",
     "i18n": {
       "es": {
         "name": "Flujo de Chat",
@@ -662,7 +662,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -677,12 +677,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.8.1",
-    "releasedAt": "2026-07-31",
+    "testedOpenWAVersion": "0.12.1",
+    "releasedAt": "2026-08-01",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.0/faq-bot.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.1/faq-bot.zip",
     "i18n": {
       "es": {
         "name": "Bot de Preguntas Frecuentes / Respuesta Automática",


### PR DESCRIPTION
Three plugins move `testedOpenWAVersion` from 0.8.1 to 0.12.1, each with a patch bump. No behaviour changed; the field is defined as the newest host the plugin was actually smoke-tested against, and that smoke has now been run.

All three were installed at these versions on a live OpenWA 0.12.1 host with a connected WhatsApp session, **all enabled at the same time alongside two other responder plugins**, and driven by real messages from a second connected number. Each answered exactly the messages meant for it, and every message was answered by exactly one plugin:

- a message matching a `faq-bot` keyword rule was answered by `faq-bot` alone;
- a message matching `chat-flow`'s trigger started its menu flow, answered by `chat-flow` alone, and `chat-flow` then continued to own the contact's replies while they were inside the menu;
- a message matching nothing specific fell through to the catch-all responder;
- with that catch-all disabled, `after-hours` answered the same kind of message with its away message.

Before this ordering existed, each of those messages would have drawn a reply from all three.

Not covered, and stated as such in each changelog: group chats, media, and behaviour under load.