### PR TITLE
chore: record OpenWA 0.14.0 as the tested host

### DIFF
--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -19,7 +19,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.14.0) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": [
     "auto-reply"
   ],

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.14.0) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": [
     "auto-reply"
   ],

--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -21,7 +21,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.7 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.8.7 (tested 0.14.0) |
 | **Keywords** | chatwoot, helpdesk, inbox, handover, two-way, agent, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chatwoot-adapter](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter) |
 <!-- END DETAILS -->
@@ -155,6 +155,10 @@ instance id or route — so re-copy the ingress URL from the mint response.
   gate, `net.allowConfigHosts`), the `conversation.send` media/voice types for outbound attachments, the
   sandbox-bridged `engine.getChatHistory` for the history backfill, and `engine.canonicalChatId` for `@lid`
   resolution.
+- **Agent replies containing a link look plainer from OpenWA 0.14.0 on the Baileys engine.** WhatsApp used
+  to draw a preview card for a URL in an agent's reply. From 0.14.0 Baileys only generates that card when
+  the sender asks for it, and a plugin has no way to ask, so those replies arrive as plain links. Delivery
+  is unaffected. The whatsapp-web.js engine is unaffected.
 - **`@lid` migration** — when a contact migrates to WhatsApp's `@lid` addressing, their conversation is kept
   from splitting as long as the lid→phone mapping is known (after any reply to them). To resolve it on
   every inbound too — closing the gap for a contact you've only ever received from — set

--- a/chatwoot-adapter/manifest.json
+++ b/chatwoot-adapter/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["chatwoot", "helpdesk", "inbox", "handover", "two-way", "agent", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.7",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send", "webhook:ingress", "engine:read"],
   "net": { "allow": [], "allowConfigHosts": ["baseUrl"] },

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.14.0) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": [
     "auto-reply"
   ],

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.14.0) |
 | **Keywords** | translation, libretranslate, i18n, groups, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/group-translate](https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate) |
 <!-- END DETAILS -->

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": [
     "translation"
   ],

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.8.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.14.0) |
 | **Keywords** | google-sheets, logging, audit, crm, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["google-sheets", "logging", "audit", "crm", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.8.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": ["message-logging"],
   "permissions": ["net:fetch"],
   "net": { "allow": ["oauth2.googleapis.com", "sheets.googleapis.com"] },

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.0 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested 0.14.0) |
 | **Keywords** | api, rest, automation, connector, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/http-action](https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action) |
 <!-- END DETAILS -->

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -18,7 +18,7 @@
     "openwa"
   ],
   "status": "stable",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
   "provides": [

--- a/plugins.json
+++ b/plugins.json
@@ -17,7 +17,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -213,7 +213,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -386,7 +386,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.7",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "chatwoot-adapter",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -677,7 +677,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -848,7 +848,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1115,7 +1115,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.8.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-07-31",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1310,7 +1310,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.0",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1579,7 +1579,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.16",
-    "testedOpenWAVersion": "0.8.16",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-07-30",
     "repoPath": "supabase-otp-hook",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1752,7 +1752,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.2",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-07-31",
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
@@ -1997,7 +1997,7 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.12.1",
+    "testedOpenWAVersion": "0.14.0",
     "releasedAt": "2026-08-01",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -21,7 +21,7 @@
 | **Author** | maplerichie |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.16 (tested 0.8.16) |
+| **Requires OpenWA** | ≥ 0.8.16 (tested 0.14.0) |
 | **Keywords** | supabase, auth, otp, sms, whatsapp, verification, standard-webhooks, openwa |
 | **Repository** | [OpenWA-plugins/supabase-otp-hook](https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook) |
 <!-- END DETAILS -->

--- a/supabase-otp-hook/manifest.json
+++ b/supabase-otp-hook/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["supabase", "auth", "otp", "sms", "whatsapp", "verification", "standard-webhooks", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.8.16",
-  "testedOpenWAVersion": "0.8.16",
+  "testedOpenWAVersion": "0.14.0",
   "sdkVersion": "1",
   "permissions": ["webhook:ingress", "messages:send"],
   "sessionScoped": true,

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.2 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.8.2 (tested 0.14.0) |
 | **Keywords** | typebot, chatbot, flow, bot, no-code, two-way, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/typebot-connector](https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector) |
 <!-- END DETAILS -->
@@ -111,6 +111,11 @@ and upload it in the dashboard **Plugins → Install** (or the **Catalog** tab).
   tell whose flow it belongs to, and guessing would feed one contact's answer into another's session.
 - `payment` steps and non-renderable embeds can't be shown on WhatsApp and get a short fallback
   message. Streaming AI blocks are resolved server-side into normal text bubbles.
+- **Link bubbles look plainer from OpenWA 0.14.0 on the Baileys engine.** A link bubble and a redirect
+  step are sent as the bare URL, and WhatsApp used to draw a preview card for them. From 0.14.0 Baileys
+  only generates that card when the sender asks for it, and a plugin has no way to ask — so these
+  bubbles arrive as plain links. Nothing is lost and every link still works; if the card matters, put
+  the context in the bubble's own text. The whatsapp-web.js engine is unaffected.
 
 ### Per-session config
 

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -12,7 +12,7 @@
   "keywords": ["typebot", "chatbot", "flow", "bot", "no-code", "two-way", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.2",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send"],
   "net": { "allow": [], "allowConfigHosts": ["apiHost", "mediaHost"] },

--- a/types/openwa.d.ts
+++ b/types/openwa.d.ts
@@ -1,7 +1,7 @@
 // Vendored OpenWA plugin contract. There is no published @openwa SDK package; keep this in sync
 // with the OpenWA version you target. All imports of this module must be `import type`.
 //
-// Last aligned against OpenWA core v0.12.0 (tag), verified field-by-field against
+// Last aligned against OpenWA core v0.14.0 (tag), verified field-by-field against
 // src/core/plugins/plugin.interfaces.ts, src/core/hooks/hook.interfaces.ts, plugin-net.ts,
 // sandbox/{worker-bootstrap,worker-capability,worker-hooks,worker-webhooks}.ts and
 // src/engine/interfaces/whatsapp-engine.interface.ts. Where this file narrows the host on purpose it
@@ -236,9 +236,10 @@ export type PluginI18n = Record<string, PluginI18nLocale>;
  *
  * One member is deliberately NOT vendored: `registerSearchProvider`, which the host does provide. No
  * plugin here is a search backend, and typing it would mean hand-copying the host's SearchQuery /
- * SearchResults shapes with nothing to keep them honest. Note it is ungated by any permission, and
- * under the default SEARCH_PROVIDER=auto a plugin that registers becomes the gateway's ACTIVE search
- * backend — worth knowing before adding it.
+ * SearchResults shapes with nothing to keep them honest. Adding it needs the `search:provide`
+ * permission in the manifest (required since core 0.12.2 — the host denies the registration outright
+ * without it), and under the default SEARCH_PROVIDER=auto a plugin that registers becomes the
+ * gateway's ACTIVE search backend, superseding builtin-fts — worth knowing before adding it.
  */
 export interface PluginContext {
   pluginId: string;

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -20,7 +20,7 @@
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.12.1) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.14.0) |
 | **Keywords** | transcription, speech-to-text, stt, whisper, voice, audio, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/voice-transcription](https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription) |
 <!-- END DETAILS -->

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -21,7 +21,7 @@
   ],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.12.1",
+  "testedOpenWAVersion": "0.14.0",
   "provides": [
     "transcription"
   ],


### PR DESCRIPTION
## What

Records OpenWA **0.14.0** as the tested host for all ten plugins, and fixes two pieces of documentation that had gone stale.

- `testedOpenWAVersion` → `0.14.0` in every manifest (eight were on `0.12.1`, gsheets-logger on `0.8.1`, supabase-otp-hook on `0.8.16`), with `plugins.json` and the README badges regenerated.
- `version` and `minOpenWAVersion` are untouched, and no download URL changed — the catalog cannot advertise a release that does not exist yet.

No plugin needed a code change.

## Why the bump is safe

Verified against core 0.14.0 rather than assumed. Comparing blob hashes between the `v0.12.1` and `v0.14.0` tags, these are byte-identical: the manifest schema, the net allowlist, activation, the handover gate, webhook-ingress subscription, the hook interfaces, and the entire sandbox worker tree. Every permission string and hook name these plugins declare still exists and is still emitted with the same payload. The manifest schema gained no field, and `SUPPORTED_SDK_MAJOR` is still `1`.

The loader shrank by around 1,100 lines in this window, which looks alarming in a diff stat but is a decomposition into `plugin-sandbox-bridge.ts` and `plugin-capability-context.ts` — every capability verb, gate, timeout and error string is preserved.

`testedOpenWAVersion` is never enforced by the host; it is catalog display metadata. Bumping it is documentation, and that is the point — it tells operators which host these were actually exercised against.

## Two behaviour notes

Baileys stopped generating link previews unless the sender asks for it, and the plugin send path has no way to ask — `ConversationSendEnvelope` has no `linkPreview` field. Two plugins are affected in a way a user would notice, and both now say so in their README:

- **typebot-connector** — link and redirect bubbles are sent as a bare URL, so the preview card *was* the content.
- **chatwoot-adapter** — an agent reply containing a link arrives as a plain link.

Reply-only plugins (after-hours, chat-flow, faq-bot, http-action) are unaffected, quoted replies keep their preview, and the whatsapp-web.js engine is unaffected entirely. Adding `linkPreview` to the plugin send envelope is worth a separate request upstream; the REST send DTO already has it.

## Also

`registerSearchProvider` has required the `search:provide` permission since core 0.12.2 — the host denies the registration outright without it. The vendored contract still told readers it was ungated, which would have sent anyone adding a search backend down a confusing path.

## Verification

`npx tsc --noEmit` clean, 535/535 tests passing, `node scripts/catalog.mjs --check` reports the catalog up to date.

Worth flagging separately: `tsconfig.json` compiles against the vendored `types/openwa.d.ts`, and there is no sync script or drift guard for that file. A green typecheck proves internal consistency, not host compatibility — the compatibility claims above rest on reading core, not on the exit code.