### PR TITLE
docs: correct the gateway URLs and the shipped-status claims

### DIFF
--- a/PLUGIN-STANDARD.md
+++ b/PLUGIN-STANDARD.md
@@ -56,9 +56,9 @@ OpenWA-plugins/
   "net": { "allow": ["api.example.com:443"] }, // outbound-HTTP allowlist for ctx.net.fetch (needs "net:fetch")
   "configUi": { "entry": "config/index.html", "height": 600 }, // sandboxed-iframe config editor (see below)
 
-  // ── Returned by the API (not yet rendered by the dashboard) ──
+  // ── Returned by the API; `author` shows on the catalog row and is searchable there ──
   "author": "Name <email>",     // string form (npm-style)
-  "license": "MIT",
+  "license": "MIT",            // stored and returned, not rendered
 
   // ── Standard catalog metadata (OpenWA stores but ignores; used by our tooling) ──
   "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/my-plugin",
@@ -356,7 +356,8 @@ One entry per plugin, written by `scripts/catalog.mjs` from each manifest + chan
 
 Size and sha256 are **not** in the catalog — they are release artifacts (GitHub Release notes/assets),
 so the catalog stays deterministic and CI's drift check stays stable. This file is also the data source
-for a future OpenWA in-dashboard marketplace.
+for the OpenWA in-dashboard marketplace, which the Plugins page reads to offer catalog installs
+alongside uploads.
 
 ## Tooling (npm scripts)
 
@@ -375,4 +376,5 @@ for a future OpenWA in-dashboard marketplace.
 Tag a release as **`<plugin-id>-vX.Y.Z`** (the version must match the manifest + changelog). The
 `release` GitHub Action builds the plugin, attaches `<id>.zip` + `<id>.zip.sha256` to a GitHub Release,
 and uses the matching CHANGELOG section as the release notes. Users install by downloading that asset
-and uploading it in the dashboard (until the in-dashboard marketplace lands).
+and uploading it in the dashboard. The dashboard can also install straight from this catalog — the
+Plugins page offers Upload and Catalog as two modes of the same install flow.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Plugins are managed by an **ADMIN** API key, either through the OpenWA dashboard
 **1. Build the plugin package** (see [Building from source](#building-from-source)) to get `gsheets-logger.zip`, then upload it:
 
 ```bash
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" \
   -F "file=@gsheets-logger.zip"
 ```
@@ -90,7 +90,7 @@ curl -X POST "https://your-openwa-host/plugins/install" \
 **2. Configure it** (secrets are masked on read and preserved on write):
 
 ```bash
-curl -X PUT "https://your-openwa-host/plugins/gsheets-logger/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/gsheets-logger/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" \
   -H "Content-Type: application/json" \
   -d '{ "config": { "spreadsheetId": "1AbC...defG", "serviceAccountJson": "{...}", "sheetTab": "Logs" } }'
@@ -103,7 +103,7 @@ runtime status. What is not automatic is a worker that crashed mid-run: nothing 
 next restart or an explicit re-enable.
 
 ```bash
-curl -X POST "https://your-openwa-host/plugins/gsheets-logger/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/gsheets-logger/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -4,7 +4,7 @@
 
 ![type: extension](https://img.shields.io/badge/type-extension-blue.svg)
 ![license: MIT](https://img.shields.io/badge/license-MIT-green.svg)
-![built for OpenWA](https://img.shields.io/badge/OpenWA-%E2%89%A5%200.6.2-25D366.svg)
+![built for OpenWA](https://img.shields.io/badge/OpenWA-%E2%89%A5%200.7.0-25D366.svg)
 [![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frmyndharis%2FOpenWA-plugins%2Fbadges%2Fdownloads%2Fafter-hours.json)](https://github.com/rmyndharis/OpenWA-plugins/releases?q=after-hours)
 
 ## Details
@@ -48,7 +48,7 @@ absent day is also closed. Times are 24-hour, `open < close` (same-day):
 
 ## Setup
 
-1. Have OpenWA **≥ 0.6.2** running with a logged-in WhatsApp session.
+1. Have OpenWA **≥ 0.7.0** running with a logged-in WhatsApp session.
 2. Install and enable the plugin (see [Install](#install)).
 3. Set your weekly schedule, timezone, and away message (see [Configuration](#configuration)) — the
    schedule is interpreted in your `timezone` via `Intl`, independent of the host clock.
@@ -58,14 +58,14 @@ absent day is also closed. Times are 24-hour, `open < close` (same-day):
 ```bash
 node package.mjs after-hours    # produces after-hours.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@after-hours.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/after-hours/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/after-hours/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "schedule": "{\"mon\":\"09:00-17:00\",\"sun\":null}", "timezone": "Asia/Jakarta", "awayMessage": "Terima kasih! Kami sedang tutup dan akan membalas di jam kerja." } }'
 
-curl -X POST "https://your-openwa-host/plugins/after-hours/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/after-hours/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 
@@ -84,8 +84,10 @@ and upload it in the dashboard **Plugins → Install** (or the **Catalog** tab).
 
 ## Compatibility
 
-Targets OpenWA **≥ 0.6.2** (sandboxed runtime with `Intl` timezone data and `onConfigChange` forwarding,
-so schedule edits apply live without a re-enable).
+Targets OpenWA **≥ 0.7.0**, which is what the manifest declares and what the catalog publishes. The
+runtime features it relies on — sandboxed `Intl` timezone data and `onConfigChange` forwarding, so
+schedule edits apply live without a re-enable — arrived in 0.6.2, but the supported floor is the
+declared one.
 
 ### Per-session config
 

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -76,16 +76,16 @@ sandboxed frame. A reply that doesn't match any option re-sends the current menu
 ```bash
 node package.mjs chat-flow    # produces chat-flow.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@chat-flow.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/chat-flow/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/chat-flow/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "trigger": "menu", "greeting": "Hi! 1. Pricing 2. Support",
         "options": [ { "key": "1", "text": "Plans start at Rp100.000" },
                      { "key": "2", "text": "Email support@example.com" } ] } }'
 
-curl -X POST "https://your-openwa-host/plugins/chat-flow/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/chat-flow/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -60,14 +60,14 @@
 ```bash
 node package.mjs faq-bot    # produces faq-bot.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@faq-bot.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/faq-bot/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/faq-bot/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "rules": "[{\"mode\":\"contains\",\"pattern\":\"harga\",\"reply\":\"Harga mulai 100rb\"}]" } }'
 
-curl -X POST "https://your-openwa-host/plugins/faq-bot/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/faq-bot/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -81,14 +81,14 @@ Default prefix `/tr` (configurable). Read-only commands are open; the rest are a
 # Build from source (released .zip files are on the Releases page):
 node package.mjs group-translate    # produces group-translate.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@group-translate.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/group-translate/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/group-translate/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "libretranslateUrl": "http://libretranslate:7001", "timeoutMs": 4000 } }'
 
-curl -X POST "https://your-openwa-host/plugins/group-translate/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/group-translate/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -174,14 +174,14 @@ Send yourself a WhatsApp message, then confirm the pipeline end to end:
 ```bash
 node package.mjs gsheets-logger    # produces gsheets-logger.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@gsheets-logger.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/gsheets-logger/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/gsheets-logger/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "spreadsheetId": "<ID>", "serviceAccountJson": "<paste JSON>", "sheetTab": "Logs" } }'
 
-curl -X POST "https://your-openwa-host/plugins/gsheets-logger/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/gsheets-logger/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -77,14 +77,14 @@ passing nothing. Guard any template that must have a number, e.g. with a `notFou
 ```bash
 node package.mjs http-action    # produces http-action.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@http-action.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/http-action/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/http-action/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "baseUrl": "https://erp.example.com", "actions": "[{\"id\":\"check-order\",\"match\":{\"type\":\"prefix\",\"value\":\"cek-order \"},\"request\":{\"method\":\"GET\",\"path\":\"/orders/{{args.0}}\"},\"replyTemplate\":\"Order {{response.orderId}}: {{response.status}}\"}]" } }'
 
-curl -X POST "https://your-openwa-host/plugins/http-action/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/http-action/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -1,0 +1,52 @@
+// README claims that can silently contradict the manifest or the gateway.
+//
+// Each of these drifted at least once. A README is the only place most users read a version floor or
+// a curl command, and nothing else in the toolchain looks at either — the catalog gate compares
+// manifests to plugins.json and never opens a README.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pluginDirs = readdirSync(root, { withFileTypes: true })
+  .filter(d => d.isDirectory() && existsSync(join(root, d.name, 'manifest.json')))
+  .map(d => d.name);
+
+const readmes = [join(root, 'README.md'), ...pluginDirs.map(d => join(root, d, 'README.md'))].filter(existsSync);
+
+test('every gateway URL in a README carries the /api prefix', () => {
+  // The gateway mounts a global `/api` prefix, so `<host>/plugins/...` answers 404. 27 copy-pasteable
+  // curl commands addressed it without the prefix.
+  const offenders = [];
+  for (const file of readmes) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(/https?:\/\/[^\s'"`)]+/g)) {
+      const url = m[0];
+      if (!/your-openwa-host|localhost:2785/.test(url)) continue;
+      const path = url.replace(/^https?:\/\/[^/]+/, '');
+      if (path && path !== '/' && !path.startsWith('/api/')) offenders.push(`${file.replace(root + '/', '')}: ${url}`);
+    }
+  }
+  assert.deepEqual(offenders, []);
+});
+
+test("each plugin README's stated OpenWA floor matches its manifest", () => {
+  // after-hours carried a hand-maintained badge and two prose mentions saying 0.6.2 while the manifest
+  // declared 0.7.0 — three numbers, one of them the one the catalog actually publishes.
+  const mismatches = [];
+  for (const dir of pluginDirs) {
+    const readme = join(root, dir, 'README.md');
+    if (!existsSync(readme)) continue;
+    const declared = JSON.parse(readFileSync(join(root, dir, 'manifest.json'), 'utf8')).minOpenWAVersion;
+    if (!declared) continue;
+    const text = readFileSync(readme, 'utf8');
+    const stated = new Set();
+    for (const m of text.matchAll(/badge\/OpenWA-%E2%89%A5%20([0-9.]+)-/g)) stated.add(m[1]);
+    for (const m of text.matchAll(/OpenWA\s*\*\*≥\s*([0-9.]+)\*\*/g)) stated.add(m[1]);
+    for (const v of stated) if (v !== declared) mismatches.push(`${dir}: README says ${v}, manifest says ${declared}`);
+  }
+  assert.deepEqual(mismatches, []);
+});

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -73,14 +73,14 @@ The same applies to a `choice` step, which arrives as a numbered list the contac
 ```bash
 node package.mjs typebot-connector    # produces typebot-connector.zip at the repo root
 
-curl -X POST "https://your-openwa-host/plugins/install" \
+curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" -F "file=@typebot-connector.zip"
 
-curl -X PUT "https://your-openwa-host/plugins/typebot-connector/config" \
+curl -X PUT "https://your-openwa-host/api/plugins/typebot-connector/config" \
   -H "X-API-Key: <ADMIN_API_KEY>" -H "Content-Type: application/json" \
   -d '{ "config": { "apiHost": "https://typebot.io", "publicId": "<public-id>" } }'
 
-curl -X POST "https://your-openwa-host/plugins/typebot-connector/enable" \
+curl -X POST "https://your-openwa-host/api/plugins/typebot-connector/enable" \
   -H "X-API-Key: <ADMIN_API_KEY>"
 ```
 

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -100,16 +100,16 @@ out of order — do not assume ordering).
 
 ```bash
 # Upload the packaged zip
-curl -X POST http://localhost:2785/plugins/install \
+curl -X POST http://localhost:2785/api/plugins/install \
   -H "X-API-Key: $OPENWA_API_KEY" -F "file=@voice-transcription.zip"
 
 # Configure (per session, or '*' for all)
-curl -X PUT http://localhost:2785/plugins/voice-transcription/config \
+curl -X PUT http://localhost:2785/api/plugins/voice-transcription/config \
   -H "X-API-Key: $OPENWA_API_KEY" -H 'Content-Type: application/json' \
   -d '{"sttBaseUrl":"http://127.0.0.1:8000","model":"small","deliveryWebhookUrl":"http://127.0.0.1:5678/webhook/transcript"}'
 
 # Enable
-curl -X POST http://localhost:2785/plugins/voice-transcription/enable \
+curl -X POST http://localhost:2785/api/plugins/voice-transcription/enable \
   -H "X-API-Key: $OPENWA_API_KEY"
 ```
 


### PR DESCRIPTION
## Three claims that were not true

### Gateway URLs — the one users hit

**27** copy-pasteable `curl` commands, across the root README and eight plugin READMEs, addressed the gateway as `<host>/plugins/...`.

The gateway mounts a global `/api` prefix. Every one of those commands answers `404` — install, enable and config alike. Verified against the published contract: `/api/plugins/install`, `/api/plugins/{id}/enable` and `/api/plugins/{id}/config` all exist; a bare `/plugins/install` does not.

### Marketplace status

`PLUGIN-STANDARD.md` called the in-dashboard marketplace future work in two places, and told users to install by downloading a release asset *"until the in-dashboard marketplace lands"*.

It has landed. The dashboard's Plugins page offers **Upload** and **Catalog** as two modes of one install flow, reading this very catalog — with search over it.

The adjacent metadata note claiming the API-returned fields are *"not yet rendered by the dashboard"* was stale too, but only halfway: the catalog row renders `author` and searches on it, while `license` really is stored-but-unrendered. Corrected per field rather than flipped wholesale.

### after-hours compatibility floor

The README stated **two different floors 15 lines apart** — a hand-maintained badge and two prose mentions saying `0.6.2`, and a generator-owned table row saying `0.7.0`.

The manifest declares `0.7.0`, and that is what the catalog publishes, so the three hand-written mentions were the wrong ones. The reason the plugin needs a floor at all — sandboxed `Intl` timezone data and `onConfigChange` forwarding — did arrive in 0.6.2, so that survives as an explanation rather than as a competing number.

## Tests

Two guards, because nothing in the toolchain reads a README: the catalog gate compares manifests against `plugins.json` and never opens one.

- every gateway URL in any README must carry the `/api` prefix
- a plugin README's stated OpenWA floor must equal its own `manifest.json`

Both mutation-checked: reverting one URL and one floor fails exactly those two tests and nothing else.

## Verification

547 tests passing, and `node scripts/catalog.mjs --check` reports the catalog up to date — no manifest or catalog data changed here.