### PR TITLE
docs(supabase-otp-hook): scope the dead-session 503 to the option that has it

### DIFF
--- a/supabase-otp-hook/CHANGELOG.md
+++ b/supabase-otp-hook/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this plugin are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The README no longer promises a dead-session `503` that Option B cannot deliver** — the host
+  preflight probes the instance's `sessionScope`, so a blank scope skips the check and a delivery whose
+  fallback session is down is acked `200` and lost with no provider retry. Both the provisioning list
+  and the Security section now scope that guarantee to Option A.
+
 ## [0.3.0] — 2026-07-30
 
 ### Removed

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -79,6 +79,11 @@ the Standard Webhooks signature).
 
 - **Option A — bind to a session.** Set `sessionScope` to a logged-in WhatsApp session id. Simplest.
 - **Option B — use a fallback.** Leave `sessionScope` blank, set `fallbackSessionId` in plugin config.
+  ⚠️ **This gives up the dead-session 503.** The host preflight probes the *instance* scope, and a blank
+  scope has no single session to probe — `fallbackSessionId` is plugin config the host never sees. So a
+  delivery whose fallback session is down is answered `200 {"ok":true}`, Supabase treats it as
+  delivered and does not retry, and the OTP is lost. The only trace is the plugin's
+  `sendText failed (background)` log line. Prefer Option A wherever the sending session is known.
 - **Option C — misconfiguration.** Both blank → the handler drops the delivery (no session to send from).
 
 > The plugin's **Sessions** tab controls *activity*, not *which session sends*. Sending session = `sessionScope` or `fallbackSessionId`, in that order.
@@ -163,7 +168,9 @@ set `fallbackSessionId`.
 
 - Webhook secret stored as the instance secret (masked on dashboard reads after mint).
 - Signature verified **host-side, before any send or plugin code runs**, constant-time compare, 5-min replay window.
-- A bad signature returns **401** synchronously; a dead session returns **503** synchronously (host-side preflight) — neither reaches the plugin.
+- A bad signature returns **401** synchronously. A dead session returns **503** synchronously **only under
+  Option A** — the host-side preflight probes the instance's `sessionScope`, so a blank scope (Option B)
+  skips the check and the delivery is acked `200` before the plugin runs. Neither case reaches plugin code.
 - Permissions: `webhook:ingress` + `messages:send` only (liveness is checked host-side, so no `engine:read`).
 
 ## Changelog


### PR DESCRIPTION
## The claim that was wrong

The README stated, without qualification:

> A bad signature returns **401** synchronously; a dead session returns **503** synchronously (host-side preflight) — neither reaches the plugin.

That holds for **Option A** only.

## Why Option B cannot have it

The host preflight probes the **instance's** `sessionScope`. Option B leaves that blank and puts the sending session in `fallbackSessionId` — plugin config the host never sees. `evaluatePreflight` therefore finds no single session to probe and skips the `session-alive` check, exactly as its own comment says (*"wildcard: no single session to probe"*).

The route is a sync-response route, so the ack is rendered and returned **before** dispatch. By the time the plugin resolves the fallback and the send fails, the `200` is already committed. There is no point at which the plugin could turn it into a `503`.

## Why that matters here specifically

On an auth path the failure mode is the bad kind. Supabase reads `200 {"ok":true}` as delivered and does not retry; the dedup row suppresses a repeat; no DLQ row and no message row are written. The only trace is the plugin's own `sendText failed (background)` log line.

It is conditional — it needs the Option-B choice **and** a fallback session with no live engine at request time — and Option A is what the README calls "Simplest". But an operator who picked Option B was told they had a guarantee they did not have.

## No code changes, deliberately

Both behaviours in the chain are reasoned decisions with comments to match:

- The host renders the ack before enqueueing, because blocking it would hold the HTTP response for up to the inline dispatch timeout.
- The plugin sends fire-and-forget, because awaiting a slow send risks a 504 → provider retry → **duplicate OTP**.

Trading silent loss for duplicate OTPs on an auth path is not an improvement, and neither decision is this change's to overturn. What was wrong was the promise, not the code.

## What changed

The provisioning list now says what Option B gives up, and the Security section scopes the `503` to Option A. A changelog entry records it.