### PR TITLE
feat(catalog): publish what each plugin declares it binds

### DIFF
--- a/PLUGIN-STANDARD.md
+++ b/PLUGIN-STANDARD.md
@@ -350,9 +350,34 @@ One entry per plugin, written by `scripts/catalog.mjs` from each manifest + chan
   "keywords", "minOpenWAVersion", "testedOpenWAVersion",
   "releasedAt",           // from the top CHANGELOG heading
   "repoPath", "repoUrl", "homepage",
-  "download"              // predictable GitHub Release asset URL: <repo>/releases/download/<id>-v<version>/<id>.zip
+  "download",             // predictable GitHub Release asset URL: <repo>/releases/download/<id>-v<version>/<id>.zip
+
+  // What the plugin DECLARES it binds — see the caveat below before treating any of it as a guarantee.
+  "permissions",          // the capability permissions from the manifest
+  "net",                  // the manifest `net` block, or null
+  "ingress",              // [{ route, methods, signature }] per declared ingress route, or null
+  "sessionScoped"         // whether activation is per-session
 }
 ```
+
+### What the declared fields are, and are not
+
+They let a reader compare a plugin's stated purpose against the host capabilities it asks for, before
+installing it. A translation plugin that declares `webhook:ingress`, or a logger whose `net.allow`
+names a host its README never mentions, is worth a second look. The `ingress` entries matter most:
+a provisioned ingress route is a `@Public()` endpoint, so knowing which routes a plugin opens — and
+whether they are signed — is information you want *before* the install, not after.
+
+> ⚠️ **They are not a security boundary, and must never be presented as one.**
+> [`docs/30-plugin-sandboxing.md`](https://github.com/rmyndharis/OpenWA/blob/main/docs/30-plugin-sandboxing.md)
+> is explicit: a `worker_thread` is a separate V8 context **in the same OS process, under the same
+> user** — not an OS-level sandbox. A plugin keeps `require('fs')`, `process` and raw sockets
+> whatever it declares here, and `net.allow` gates the host-mediated `ctx.net.fetch`, not the
+> plugin's own outbound traffic.
+>
+> So an empty `permissions` array means the plugin binds no *mediated* capability. It does not mean
+> the plugin can do nothing. Reading this list as an enforcement guarantee is worse than not
+> publishing it at all — which is why it ships with this paragraph attached.
 
 Size and sha256 are **not** in the catalog — they are release artifacts (GitHub Release notes/assets),
 so the catalog stays deterministic and CI's drift check stays stable. This file is also the data source

--- a/plugins.json
+++ b/plugins.json
@@ -23,6 +23,12 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.1/after-hours.zip",
+    "permissions": [
+      "messages:send"
+    ],
+    "net": null,
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Respuesta Automática Fuera de Horario",
@@ -219,6 +225,12 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.1/chat-flow.zip",
+    "permissions": [
+      "messages:send"
+    ],
+    "net": null,
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Flujo de Chat",
@@ -392,6 +404,26 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.0/chatwoot-adapter.zip",
+    "permissions": [
+      "net:fetch",
+      "conversation:send",
+      "webhook:ingress",
+      "engine:read"
+    ],
+    "net": {
+      "allow": [],
+      "allowConfigHosts": [
+        "baseUrl"
+      ]
+    },
+    "ingress": [
+      {
+        "route": "chatwoot",
+        "methods": null,
+        "signature": "hmac-sha256"
+      }
+    ],
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Adaptador de Chatwoot",
@@ -683,6 +715,12 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.1/faq-bot.zip",
+    "permissions": [
+      "messages:send"
+    ],
+    "net": null,
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Bot de Preguntas Frecuentes / Respuesta Automática",
@@ -854,6 +892,22 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.0/group-translate.zip",
+    "permissions": [
+      "messages:send",
+      "engine:read",
+      "net:fetch"
+    ],
+    "net": {
+      "allow": [
+        "localhost",
+        "127.0.0.1"
+      ],
+      "allowConfigHosts": [
+        "libretranslateUrl"
+      ]
+    },
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Traducción Automática de Grupos",
@@ -1121,6 +1175,17 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.2/gsheets-logger.zip",
+    "permissions": [
+      "net:fetch"
+    ],
+    "net": {
+      "allow": [
+        "oauth2.googleapis.com",
+        "sheets.googleapis.com"
+      ]
+    },
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Registrador en Google Sheets",
@@ -1316,6 +1381,18 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.1/http-action.zip",
+    "permissions": [
+      "net:fetch",
+      "conversation:send"
+    ],
+    "net": {
+      "allow": [],
+      "allowConfigHosts": [
+        "baseUrl"
+      ]
+    },
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Bot de acciones HTTP",
@@ -1585,6 +1662,19 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.0/supabase-otp-hook.zip",
+    "permissions": [
+      "webhook:ingress",
+      "messages:send"
+    ],
+    "net": null,
+    "ingress": [
+      {
+        "route": "send-sms",
+        "methods": null,
+        "signature": "standard-webhooks"
+      }
+    ],
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "OTP de Supabase Auth",
@@ -1758,6 +1848,19 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.1/typebot-connector.zip",
+    "permissions": [
+      "net:fetch",
+      "conversation:send"
+    ],
+    "net": {
+      "allow": [],
+      "allowConfigHosts": [
+        "apiHost",
+        "mediaHost"
+      ]
+    },
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Conector de Typebot",
@@ -2003,6 +2106,24 @@
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
     "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.1/voice-transcription.zip",
+    "permissions": [
+      "net:fetch",
+      "messages:send"
+    ],
+    "net": {
+      "allow": [
+        "localhost",
+        "127.0.0.1",
+        "api.groq.com:443",
+        "api.openai.com:443"
+      ],
+      "allowConfigHosts": [
+        "sttBaseUrl",
+        "deliveryWebhookUrl"
+      ]
+    },
+    "ingress": null,
+    "sessionScoped": true,
     "i18n": {
       "es": {
         "name": "Transcripción de Notas de Voz",

--- a/scripts/catalog.mjs
+++ b/scripts/catalog.mjs
@@ -77,6 +77,26 @@ function buildEntry(id) {
     download: manifest.repository
       ? `${manifest.repository}/releases/download/${manifest.id}-v${manifest.version}/${manifest.id}.zip`
       : null,
+    // What the plugin DECLARES it binds. Published so a reader can compare a plugin's stated purpose
+    // against the host capabilities it asks for — a mismatch there is a real signal.
+    //
+    // NOT a security boundary, and must never be presented as one. docs/30-plugin-sandboxing.md is
+    // explicit: a worker_thread is not an OS-level sandbox, and a plugin keeps `require('fs')`,
+    // `process` and raw sockets whatever it declares here. `net.allow` gates the host-mediated
+    // `ctx.net.fetch`, not the plugin's own outbound traffic. These fields describe intent and the
+    // mediated surface; they do not constrain a malicious plugin.
+    permissions: manifest.permissions ?? [],
+    net: manifest.net ?? null,
+    // Route shapes only — an ingress route is a @Public() endpoint once provisioned, so which routes a
+    // plugin opens is worth seeing before installing it.
+    ingress: Array.isArray(manifest.ingress)
+      ? manifest.ingress.map((r) => ({
+          route: r.route,
+          methods: r.methods ?? null,
+          signature: r.signature?.scheme ?? null,
+        }))
+      : null,
+    sessionScoped: manifest.sessionScoped ?? false,
     ...(manifest.i18n ? { i18n: manifest.i18n } : {}),
   };
 }

--- a/scripts/catalog.test.mjs
+++ b/scripts/catalog.test.mjs
@@ -49,3 +49,45 @@ test('a locale that translates a plugin translates all of its config fields', ()
   }
   assert.deepEqual(gaps, []);
 });
+
+// The catalog is the data source the in-dashboard marketplace reads, and it carried nothing about what
+// a plugin binds — so "install only plugins you trust" had no in-product evidence to work from. These
+// hold the published fields to the manifests they come from.
+test('the catalog publishes what each plugin declares', () => {
+  const root = new URL('../', import.meta.url);
+  const catalog = JSON.parse(readFileSync(new URL('plugins.json', root), 'utf8'));
+  const entries = catalog.plugins ?? catalog;
+
+  const drift = [];
+  for (const e of entries) {
+    const m = JSON.parse(readFileSync(new URL(`${e.id}/manifest.json`, root), 'utf8'));
+    const declared = m.permissions ?? [];
+    if (JSON.stringify(e.permissions ?? []) !== JSON.stringify(declared)) {
+      drift.push(`${e.id}: permissions ${JSON.stringify(e.permissions)} != manifest ${JSON.stringify(declared)}`);
+    }
+    if (JSON.stringify(e.net ?? null) !== JSON.stringify(m.net ?? null)) {
+      drift.push(`${e.id}: net differs from manifest`);
+    }
+    const routes = Array.isArray(m.ingress) ? m.ingress.map((r) => r.route) : null;
+    const published = Array.isArray(e.ingress) ? e.ingress.map((r) => r.route) : null;
+    if (JSON.stringify(published) !== JSON.stringify(routes)) {
+      drift.push(`${e.id}: ingress routes ${JSON.stringify(published)} != manifest ${JSON.stringify(routes)}`);
+    }
+  }
+  assert.deepEqual(drift, []);
+});
+
+test('the ingress-declaring plugins publish their route shapes', () => {
+  // Two plugins declare ingress. A provisioned ingress route is a @Public() endpoint, so which routes
+  // exist and whether they are signed is the part worth seeing before an install.
+  const catalog = JSON.parse(readFileSync(new URL('../plugins.json', import.meta.url), 'utf8'));
+  const withIngress = (catalog.plugins ?? catalog).filter((e) => Array.isArray(e.ingress) && e.ingress.length);
+
+  assert.ok(withIngress.length >= 1, 'expected at least one plugin publishing ingress routes');
+  for (const e of withIngress) {
+    for (const r of e.ingress) {
+      assert.ok(typeof r.route === 'string' && r.route.length, `${e.id} ingress entry has no route`);
+      assert.ok('signature' in r, `${e.id} ingress entry does not say whether it is signed`);
+    }
+  }
+});


### PR DESCRIPTION
## What

The generated catalog carried **17 keys** and not one of them said what a plugin binds — no capability permissions, no network allowlist, no ingress routes.

That catalog is the data source the in-dashboard marketplace reads. So the repository's own guidance — install only plugins you trust — had no in-product evidence behind it: an operator had to come here and open the manifest.

Four fields are published now:

| Field | What it carries |
| --- | --- |
| `permissions` | the manifest's capability permissions |
| `net` | the manifest `net` block, or `null` |
| `ingress` | `[{ route, methods, signature }]` per declared route, or `null` |
| `sessionScoped` | whether activation is per-session |

Core's `CatalogEntry` declares `[key: string]: unknown` with the comment *"Extra fields are tolerated"*, so this needs **no gateway change** and older instances ignore it.

## Why the ingress shapes earn their place most

A provisioned ingress route is a `@Public()` endpoint. Which routes a plugin opens — and whether they are signed — is exactly the thing worth knowing *before* an install rather than after one.

## The caveat is the point, not a footnote

`docs/30-plugin-sandboxing.md` says it in bold: a `worker_thread` is a separate V8 context **in the same OS process, under the same user** — not an OS-level sandbox. A plugin keeps `require('fs')`, `process` and raw sockets whatever it declares here, and `net.allow` gates the host-mediated `ctx.net.fetch`, not the plugin's own outbound traffic.

So an empty `permissions` array means the plugin binds no *mediated* capability. It does **not** mean the plugin can do nothing.

`PLUGIN-STANDARD.md` now carries that paragraph directly beside the field list. **Publishing these fields without it would be worse than not publishing them** — a reader would take an allowlist for a constraint, and act on a guarantee that does not exist. That is the whole reason this change is shaped as "declarations of intent, documented as such" rather than a security panel.

## Tests

Two: the published fields must match the manifests they are generated from, and every plugin publishing an ingress route must say whether it is signed.

Mutation-checked — emptying one plugin's published permissions fails the first and nothing else.

## Verification

550 tests passing; `node scripts/catalog.mjs --check` reports the catalog up to date.