### PR TITLE
chore(group-translate): declare storage:use and release 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository provides:
 | [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.1 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.0 | stable |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.1 | stable |
-| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.0 | stable |
+| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.1 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.2 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.1 | stable |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,19 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-08-12
+
+### Changed
+
+- **Declared the `storage:use` permission.** Each group's settings — whether translation is on, the
+  language learned for every participant, and any delegated controllers — are kept in plugin storage.
+  OpenWA is moving `ctx.storage` behind a permission the manifest has to declare, and a plugin that
+  does not name it will have those reads and writes refused once the host enforces that. The failure
+  would surface mid-conversation rather than at install: the plugin would keep running and quietly
+  forget every group's configuration. Declaring it now costs nothing on the hosts you are running
+  today — an unrecognized permission is ignored — so this release behaves exactly like 1.3.0
+  everywhere 1.3.0 ran.
+
 ## [1.3.0] — 2026-08-01
 
 ### Fixed

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `group-translate` |
-| **Version** | 1.3.0 |
-| **Released** | 2026-08-01 |
+| **Version** | 1.3.1 |
+| **Released** | 2026-08-12 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "group-translate",
   "name": "Group Auto-Translation",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -26,7 +26,8 @@
   "permissions": [
     "messages:send",
     "engine:read",
-    "net:fetch"
+    "net:fetch",
+    "storage:use"
   ],
   "net": {
     "allow": [

--- a/plugins.json
+++ b/plugins.json
@@ -870,7 +870,7 @@
   {
     "id": "group-translate",
     "name": "Group Auto-Translation",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "type": "extension",
     "status": "stable",
     "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -886,15 +886,16 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.14.0",
-    "releasedAt": "2026-08-01",
+    "releasedAt": "2026-08-12",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.0/group-translate.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.1/group-translate.zip",
     "permissions": [
       "messages:send",
       "engine:read",
-      "net:fetch"
+      "net:fetch",
+      "storage:use"
     ],
     "net": {
       "allow": [


### PR DESCRIPTION
## What

Adds `storage:use` to `group-translate`'s declared permissions and releases 1.3.1.

## Why

The plugin keeps each group's settings in plugin storage — whether translation is on, the language learned for each participant, and any delegated controllers (`plugin-config.store.ts`, one `group:<sessionId>:<chatId>` key per group).

OpenWA is moving `ctx.storage` behind a permission the manifest has to declare. It is currently the only capability dispatched without a permission check, so a manifest could omit it and still persist data on the host. Once the host enforces the gate, a plugin that does not declare it has its storage reads and writes refused.

That failure mode is the reason this ships ahead of the host change rather than after it: the permission is checked when the verb is called, not at load. The plugin would install cleanly, appear healthy in the dashboard, and then fail while someone is using it — here, by silently forgetting a group's configuration mid-conversation.

## Compatibility

Behaviour-neutral on every host running today. Permission enforcement is a membership test against the manifest array, and there is no allowlist or manifest-schema validation that would reject an unfamiliar entry, so an older host ignores `storage:use` entirely. 1.3.1 runs exactly as 1.3.0 did.

`minOpenWAVersion` is deliberately left at 0.7.0. Raising it would cut off users whose hosts run this release perfectly well.

## Release sizing

PATCH. Following the repo standard, the release level comes from the changelog sections: this adds no capability, it declares one the plugin already uses, so the entry sits under `### Changed` and `### Changed` alone is a patch.

## Verification

```
tsc --noEmit                          0 errors
npm test                              550/550 pass, 0 fail
npm run catalog:check                 up to date (10 plugins)
node package.mjs group-translate      41.3 KB, sha256 60794cc1…
loader contract                       instantiates as IPlugin
```

The regenerated `plugins.json` now advertises the `group-translate-v1.3.1` download URL, which resolves only once the tag lands — so the tag follows this merge immediately rather than being batched with other plugins.