### PR TITLE
chore(voice-transcription): declare storage:use and release 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository provides:
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.1 | stable |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
 | [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | stable |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.2 | beta |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.3 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`

--- a/plugins.json
+++ b/plugins.json
@@ -2083,7 +2083,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -2101,14 +2101,15 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.14.0",
-    "releasedAt": "2026-08-08",
+    "releasedAt": "2026-08-12",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.2/voice-transcription.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.3/voice-transcription.zip",
     "permissions": [
       "net:fetch",
-      "messages:send"
+      "messages:send",
+      "storage:use"
     ],
     "net": {
       "allow": [

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+## [1.2.3] — 2026-08-12
+
+### Changed
+
+- **Declared the `storage:use` permission.** Two things live in plugin storage, one key each per
+  WhatsApp session: the list of voice notes already transcribed, and the hourly counter behind the
+  rate cap. OpenWA is moving `ctx.storage` behind a permission the manifest has to declare, and
+  without it both are refused — which costs money rather than just state. The de-duplication list is
+  what stops the same voice note being sent to the speech-to-text backend twice, and the counter is
+  what enforces `maxPerHour`; lose them and every redelivery becomes another paid transcription with
+  no ceiling, plus a duplicate transcript the contact sees when `chatDelivery` is set to `reply`.
+  Declaring the permission changes nothing on the hosts you run today — an unrecognized permission is
+  ignored — so 1.2.3 behaves exactly like 1.2.2.
+
 ## [1.2.2] — 2026-08-08
 
 ### Fixed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.2.2 |
-| **Released** | 2026-08-08 |
+| **Version** | 1.2.3 |
+| **Released** | 2026-08-12 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -27,7 +27,8 @@
   ],
   "permissions": [
     "net:fetch",
-    "messages:send"
+    "messages:send",
+    "storage:use"
   ],
   "net": {
     "allow": [


### PR DESCRIPTION
## What

Adds `storage:use` to `voice-transcription`'s declared permissions and releases 1.2.3.

## Why

Two keys per WhatsApp session live in plugin storage: `seen:<sessionId>`, the capped list of voice notes already transcribed, and `rate:<sessionId>`, the hourly bucket behind `maxPerHour`.

OpenWA is moving `ctx.storage` behind a permission the manifest has to declare. It is currently the only capability dispatched with no permission check. Once the host enforces the gate, an undeclared plugin has its storage reads and writes refused.

For this plugin the consequence is billable, not cosmetic. The de-duplication list is what stops a redelivered voice note being sent to the speech-to-text backend a second time, and the hourly counter is what enforces the rate cap at all. Without them every redelivery is another paid transcription with no ceiling — and under `chatDelivery: reply`, a duplicate transcript the contact sees.

The permission is checked when the verb is called rather than at load, so nothing fails at upgrade time. The plugin would enable normally and start spending.

## Compatibility

Behaviour-neutral on every host running today. Permission enforcement is a membership test against the manifest array, with no allowlist or manifest-schema validation that would reject an unfamiliar entry, so an older host ignores `storage:use`. 1.2.3 runs exactly as 1.2.2 did.

`minOpenWAVersion` stays at 0.7.0.

## Release sizing

PATCH. Per the repo standard the level follows the changelog sections: this declares a capability the plugin already uses rather than adding one, so the entry is `### Changed`, and `### Changed` alone is a patch.

## Verification

```
tsc --noEmit                            0 errors
npm test                                550/550 pass, 0 fail
npm run catalog:check                   up to date (10 plugins)
node package.mjs voice-transcription    31.9 KB, sha256 1564eb40…
loader contract                         instantiates as IPlugin
```