### PR TITLE
chore(http-action): declare storage:use and release 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository provides:
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.1 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.1 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.3 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.1 | stable |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.2 | stable |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
 | [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | stable |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.3 | beta |

--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to HTTP Action Bot are listed here. Versions follow [Semantic Versioning](https://semver.org/),
 and the top entry's version must match `manifest.json`.
 
+## [0.2.2] — 2026-08-12
+
+### Changed
+
+- **Declared the `storage:use` permission.** Answered commands are recorded in plugin storage for
+  three days, and that record is what makes a command idempotent: if the host redelivers a message,
+  the marker is what stops the REST call being made a second time. OpenWA is moving `ctx.storage`
+  behind a permission the manifest has to declare, and without it those markers cannot be written or
+  read. This plugin's job is to cause side effects in someone else's system, so losing idempotency
+  does not degrade the plugin — it means one WhatsApp command can create two orders, two tickets, or
+  two charges. Declaring the permission changes nothing on the hosts you run today: an unrecognized
+  permission is ignored, so 0.2.2 behaves exactly like 0.2.1.
+
 ## [0.2.1] — 2026-08-01
 
 ### Changed

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.2.1 |
-| **Released** | 2026-08-01 |
+| **Version** | 0.2.2 |
+| **Released** | 2026-08-12 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -28,7 +28,8 @@
   ],
   "permissions": [
     "net:fetch",
-    "conversation:send"
+    "conversation:send",
+    "storage:use"
   ],
   "net": {
     "allow": [],

--- a/plugins.json
+++ b/plugins.json
@@ -1361,7 +1361,7 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "type": "extension",
     "status": "stable",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -1377,14 +1377,15 @@
     ],
     "minOpenWAVersion": "0.8.0",
     "testedOpenWAVersion": "0.14.0",
-    "releasedAt": "2026-08-01",
+    "releasedAt": "2026-08-12",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.1/http-action.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.2/http-action.zip",
     "permissions": [
       "net:fetch",
-      "conversation:send"
+      "conversation:send",
+      "storage:use"
     ],
     "net": {
       "allow": [],


### PR DESCRIPTION
## What

Adds `storage:use` to `http-action`'s declared permissions and releases 0.2.2.

## Why

Answered commands are recorded in plugin storage as `dedup:<sessionId>:<messageId>` markers with a three-day retention and an hourly sweep. Those markers are the plugin's idempotency: when the host redelivers a message, the marker is what stops the outbound REST call being made a second time.

OpenWA is moving `ctx.storage` behind a permission the manifest has to declare. It is currently the only capability dispatched with no permission check. Once the host enforces the gate, an undeclared plugin has its storage reads and writes refused.

This plugin's entire purpose is to cause side effects in a system that is not OpenWA, which makes the consequence here different in kind from the other plugins in this catalog. Losing the dedup marker is not reduced functionality — it means one WhatsApp command can create two orders, two tickets, or two charges, in a system that has no idea the second call was a duplicate.

The permission is checked when the verb is called, not at load, so nothing fails at upgrade time. The plugin enables normally and the duplicates start on the first redelivery.

## Compatibility

Behaviour-neutral on every host running today. Permission enforcement is a membership test against the manifest array, with no allowlist or manifest-schema validation that would reject an unfamiliar entry, so an older host ignores `storage:use`. 0.2.2 runs exactly as 0.2.1 did.

`minOpenWAVersion` stays at 0.8.0.

## Release sizing

PATCH. Per the repo standard the level follows the changelog sections: this declares a capability the plugin already uses rather than adding one, so the entry is `### Changed`, and `### Changed` alone is a patch.

## Verification

```
tsc --noEmit                     0 errors
npm test                         550/550 pass, 0 fail
npm run catalog:check            up to date (10 plugins)
node package.mjs http-action     29.2 KB, sha256 8e7b4c93…
loader contract                  instantiates as IPlugin
```