### PR TITLE
chore(typebot-connector): declare storage:use and release 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository provides:
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.3 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.2 | stable |
 | [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.0 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.1 | stable |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.2 | stable |
 | [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.3 | beta |
 <!-- END PLUGIN CATALOG -->
 

--- a/plugins.json
+++ b/plugins.json
@@ -1826,7 +1826,7 @@
   {
     "id": "typebot-connector",
     "name": "Typebot Connector",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "type": "extension",
     "status": "stable",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -1844,14 +1844,15 @@
     ],
     "minOpenWAVersion": "0.8.2",
     "testedOpenWAVersion": "0.14.0",
-    "releasedAt": "2026-07-31",
+    "releasedAt": "2026-08-12",
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.1/typebot-connector.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.2/typebot-connector.zip",
     "permissions": [
       "net:fetch",
-      "conversation:send"
+      "conversation:send",
+      "storage:use"
     ],
     "net": {
       "allow": [],

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the Typebot Connector plugin are documented here. The for
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-08-12
+
+### Changed
+
+- **Declared the `storage:use` permission.** The plugin keeps one small record per conversation in
+  plugin storage — the Typebot session id, what input the bot is waiting for, and when the chat was
+  last active. Typebot owns the flow itself; this record is the only thing tying a WhatsApp chat to
+  its running Typebot session. OpenWA is moving `ctx.storage` behind a permission the manifest has to
+  declare, and without it that record cannot be read or written: every reply from a contact would be
+  treated as a brand-new conversation and restart the flow from the top, forever. Declaring the
+  permission changes nothing on the hosts you run today — an unrecognized permission is ignored — so
+  0.2.2 behaves exactly like 0.2.1.
+
 ## [0.2.1] — 2026-07-31
 
 ### Fixed

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `typebot-connector` |
-| **Version** | 0.2.1 |
-| **Released** | 2026-07-31 |
+| **Version** | 0.2.2 |
+| **Released** | 2026-08-12 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
@@ -134,6 +134,8 @@ in storage, so flows across sessions never interfere.
 - The `apiToken` is stored as a secret and sent only to your Typebot host (and only when set).
 - Bot replies originate from your Typebot flow (operator-trusted content); the plugin forwards them as
   outbound messages and declares `conversation:send` + `net:fetch`.
+- Per-conversation flow state (Typebot session id, awaited input, last activity) is kept in
+  `ctx.storage`, which the plugin declares with `storage:use`. No message content is stored.
 
 ## Changelog
 

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "typebot-connector",
   "name": "Typebot Connector",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -14,7 +14,8 @@
   "minOpenWAVersion": "0.8.2",
   "testedOpenWAVersion": "0.14.0",
   "sdkVersion": "1",
-  "permissions": ["net:fetch", "conversation:send"],
+  "permissions": ["net:fetch", "conversation:send",
+    "storage:use"],
   "net": { "allow": [], "allowConfigHosts": ["apiHost", "mediaHost"] },
   "sessionScoped": true,
   "sessions": ["*"],


### PR DESCRIPTION
## What

Adds `storage:use` to `typebot-connector`'s declared permissions, documents the storage use in the README, and releases 0.2.2.

## Why

The plugin keeps one small record per conversation under a `sess:` key: the Typebot session id, the input the bot is currently awaiting, and a last-activity stamp. Typebot owns the flow and the transcript; this record is the only thing tying a WhatsApp chat to its running Typebot session.

OpenWA is moving `ctx.storage` behind a permission the manifest has to declare. It is currently the only capability dispatched with no permission check. Once the host enforces the gate, an undeclared plugin has its storage reads and writes refused.

Losing that record does not degrade this plugin gracefully — it removes continuity entirely. Every reply from a contact would be read as a first message, start a fresh `startChat`, and send the flow's opening bubble again. A contact could never get past step one.

The permission is checked when the verb is called, not at load, so nothing fails at upgrade time. The plugin enables normally and every conversation loops.

## README

The Security section listed the plugin's declared permissions and would be incomplete as of this commit, so it now names `storage:use` and says what is stored — the session id, awaited input and activity stamp, and explicitly no message content.

## Compatibility

Behaviour-neutral on every host running today. Permission enforcement is a membership test against the manifest array, with no allowlist or manifest-schema validation that would reject an unfamiliar entry, so an older host ignores `storage:use`. 0.2.2 runs exactly as 0.2.1 did.

`minOpenWAVersion` stays at 0.8.2.

## Release sizing

PATCH. Per the repo standard the level follows the changelog sections: this declares a capability the plugin already uses rather than adding one, so the entry is `### Changed`, and `### Changed` alone is a patch.

## Verification

```
tsc --noEmit                           0 errors
npm test                               550/550 pass, 0 fail
npm run catalog:check                  up to date (10 plugins)
node package.mjs typebot-connector     31.3 KB, sha256 f760edcd…
loader contract                        instantiates as IPlugin
```