### PR TITLE
chore(chat-flow): declare storage:use and release 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository provides:
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.1 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.1 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.2 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.0 | stable |
 | [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.1 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.1 | stable |

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,18 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.2] — 2026-08-12
+
+### Changed
+
+- **Declared the `storage:use` permission.** This plugin is a state machine, and its entire state —
+  where each conversation currently sits in the menu tree — lives in plugin storage. OpenWA is moving
+  `ctx.storage` behind a permission the manifest has to declare, and without it there is nothing left
+  to run on: a contact would get the greeting and the top-level menu, then have their answer read as
+  another first message and be sent the same greeting again. This is the one plugin in the catalog for
+  which the missing declaration is total rather than partial. Declaring it changes nothing on the
+  hosts you run today — an unrecognized permission is ignored — so 1.1.2 behaves exactly like 1.1.1.
+
 ## [1.1.1] — 2026-08-01
 
 No behaviour change. 1.1.0 has now been smoke-tested against a newer host, so the tested-version field

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.1.1 |
-| **Released** | 2026-08-01 |
+| **Version** | 1.1.2 |
+| **Released** | 2026-08-12 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
@@ -37,7 +37,8 @@
   numbers it runs for. Edits apply live via `onConfigChange`.
 - **Safe under config drift** — if the saved config changes while a user is mid-flow, the stale path is
   reset with bounded re-processing (never an unbounded loop).
-- **Least privilege** — declares only `messages:send`; direct chats only unless `respondInGroups` is on.
+- **Least privilege** — declares `messages:send` and `storage:use` (flow position only); direct chats
+  only unless `respondInGroups` is on. No network access at all.
 
 ## Flow configuration
 
@@ -126,9 +127,10 @@ interfere.
 ## Security
 
 Flow state lives in `ctx.storage`, keyed per `(session, chat)` and expiring after 15 minutes — no
-cross-chat leakage. The plugin makes no outbound network calls and declares only `messages:send`. A stale
-stored path (after a config edit) is reset with bounded re-processing, so a hostile or looping config can
-never cause unbounded recursion.
+cross-chat leakage. The plugin makes no outbound network calls and declares only `messages:send` and
+`storage:use` — the latter covering that flow state, which holds a menu path and a timestamp, never
+message content. A stale stored path (after a config edit) is reset with bounded re-processing, so a
+hostile or looping config can never cause unbounded recursion.
 
 ## Changelog
 

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -25,7 +25,8 @@
     "auto-reply"
   ],
   "permissions": [
-    "messages:send"
+    "messages:send",
+    "storage:use"
   ],
   "sessionScoped": true,
   "sessions": [

--- a/plugins.json
+++ b/plugins.json
@@ -203,7 +203,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -220,13 +220,14 @@
     ],
     "minOpenWAVersion": "0.7.0",
     "testedOpenWAVersion": "0.14.0",
-    "releasedAt": "2026-08-01",
+    "releasedAt": "2026-08-12",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.1/chat-flow.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.2/chat-flow.zip",
     "permissions": [
-      "messages:send"
+      "messages:send",
+      "storage:use"
     ],
     "net": null,
     "ingress": null,


### PR DESCRIPTION
## What

Adds `storage:use` to `chat-flow`'s declared permissions, corrects two README statements, and releases 1.1.2.

## Why

`chat-flow` is a state machine. Its entire state — the path each conversation currently occupies in the menu tree, plus a last-active stamp — lives in plugin storage under one key per `(session, chat)`.

OpenWA is moving `ctx.storage` behind a permission the manifest has to declare. It is currently the only capability dispatched with no permission check. Once the host enforces the gate, an undeclared plugin has its storage reads and writes refused.

For the other plugins in this catalog the missing declaration costs a feature. Here it costs the whole plugin: a contact would get the greeting and the top-level menu, reply `1`, and have that reply read as another first message — greeting again, forever. There is no degraded mode to fall back to, because position in the tree is the only thing the plugin knows.

The permission is checked when the verb is called rather than at load, so this would not surface at upgrade time. The plugin installs, enables, shows healthy, and loops on the first real conversation.

## README

Two statements said the plugin declares only `messages:send`. One of them sits in the Security section directly after the sentence describing flow state living in `ctx.storage` — the two contradicted each other before this change and would simply have been wrong after it. Both now name `storage:use` and say what the stored value contains: a menu path and a timestamp, never message content.

## Compatibility

Behaviour-neutral on every host running today. Permission enforcement is a membership test against the manifest array, with no allowlist or manifest-schema validation that would reject an unfamiliar entry, so an older host ignores `storage:use`. 1.1.2 runs exactly as 1.1.1 did.

`minOpenWAVersion` stays at 0.7.0.

## Release sizing

PATCH. Per the repo standard the level follows the changelog sections: this declares a capability the plugin already uses rather than adding one, so the entry is `### Changed`, and `### Changed` alone is a patch.

## Verification

```
tsc --noEmit                   0 errors
npm test                       550/550 pass, 0 fail
npm run catalog:check          up to date (10 plugins)
node package.mjs chat-flow     36.3 KB, sha256 a93ff284…
loader contract                instantiates as IPlugin
```