### PR TITLE
docs: name storage:use where a README lists what the plugin declares

### DIFF
--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -111,7 +111,8 @@ Then, in the group, an admin runs `/tr on`. Or install the packaged `.zip` from
 ## Compatibility
 
 Targets OpenWA **≥ 0.7.0** — outbound HTTP uses the v0.7 `ctx.net.fetch` capability. Declares
-`messages:send`, `engine:read` (for admin checks), and `net:fetch`.
+`messages:send`, `engine:read` (for admin checks), `net:fetch`, and `storage:use` (each group's
+settings and learned participant languages).
 
 ### Per-session config
 

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -39,10 +39,11 @@ The installed version is also visible in the OpenWA dashboard Plugins list (`v0.
   dependencies**, so the package is tiny.
 - **Formula-injection safe** — writes with `valueInputOption=RAW` and neutralizes CSV/Sheets formula
   triggers, while leaving legitimate `+`/`-` content (phone numbers) intact in free-text cells.
-- **Least privilege** — declares only `net:fetch`, allowlisted to the two fixed Google hosts
+- **Least privilege** — declares `net:fetch`, allowlisted to the two fixed Google hosts
   (`oauth2.googleapis.com`, `sheets.googleapis.com`) via `net.allow`; all outbound HTTP goes through the
-  host-proxied, SSRF-guarded `ctx.net.fetch`. It only reads hook events and writes to your sheet,
-  never sends messages or reads contacts.
+  host-proxied, SSRF-guarded `ctx.net.fetch`. It also declares `storage:use` for the single key holding
+  the pending row batch. It only reads hook events and writes to your sheet, never sends messages or
+  reads contacts.
 - **Self-reporting version** — surfaces its own version in logs and `healthCheck`.
 
 ## What it logs


### PR DESCRIPTION
## What

Corrects the hand-written permission lists in `group-translate` and `gsheets-logger`'s READMEs. Documentation only — no manifest, no version, no release.

## Why

`group-translate` 1.3.1 and `gsheets-logger` 0.3.3 added `storage:use` to their manifests. Both READMEs enumerate the declared permissions in prose, so both became wrong the moment those releases went out:

- `group-translate` listed `messages:send`, `engine:read` and `net:fetch` — now incomplete.
- `gsheets-logger` said it "declares **only** `net:fetch`" — the word `only` made it an outright false statement rather than a stale one.

Both now name `storage:use` and say what it covers: each group's settings and learned participant languages, and the single key holding the pending row batch respectively.

## Why no release

The prose is not part of the packaged `.zip` (only `manifest.json`, `dist/`, and a `configUi` entry are) and not part of `plugins.json`. Nothing an operator installs changes, so a version bump would advertise a new download URL for a byte-identical artifact.

The other five plugins in this batch had their README text corrected inside their own release PRs, because the statement and the change that falsified it landed together. These two were already out.

## Gap worth noting

Nothing in the toolchain compares a README's permission claims against its manifest. `readme-claims.test.mjs` guards two other claim types that drifted before — the `/api` prefix on gateway URLs, and the stated OpenWA version floor — and this is the same shape of defect it was written for. `chat-flow` carried the sharpest version of it: its Security section said "declares only `messages:send`" one sentence after describing flow state living in `ctx.storage`.

Extending that test to pin permission claims to the manifest is a separate change and not included here.

## Verification

```
tsc --noEmit             0 errors
npm test                 550/550 pass, 0 fail
npm run catalog:check    up to date (10 plugins)
```