### PR TITLE
test: pin each README's permission claims to its manifest

### DIFF
--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -50,3 +50,78 @@ test("each plugin README's stated OpenWA floor matches its manifest", () => {
   }
   assert.deepEqual(mismatches, []);
 });
+
+// The five permissions the host enforces at the capability boundary, plus `storage:use` — the sixth,
+// added when OpenWA moved ctx.storage behind a declaration gate.
+const PERMISSIONS = ['messages:send', 'engine:read', 'net:fetch', 'conversation:send', 'webhook:ingress', 'storage:use'];
+
+// Prose wraps, so a claim and the permissions it names routinely straddle a newline: group-translate
+// ends a line on "Declares" and opens the next with the list, and chat-flow splits `messages:send` from
+// `storage:use` the same way. Anything matched across a claim has to be matched on flattened text.
+const flatten = (text) => text.replace(/\s+/g, ' ');
+
+// Classify every `permission` occurrence. A negation sitting directly in front of one ("…so no
+// `engine:read`") is a claim too — the opposite one — so it is checked in the opposite direction rather
+// than skipped. The adjacency is deliberately one word: widening it to a phrase would swallow the "no"
+// in "makes no outbound network calls and declares only `messages:send`" and invert a true claim.
+function mentionsOf(flat) {
+  const positive = new Set();
+  const negative = new Set();
+  for (const p of PERMISSIONS) {
+    for (const m of flat.matchAll(new RegExp('(\\S+ )?`' + p + '`', 'g'))) {
+      const prev = (m[1] ?? '').toLowerCase().replace(/[^a-z]/g, '');
+      (prev === 'no' || prev === 'not' || prev === 'never' ? negative : positive).add(p);
+    }
+  }
+  return { positive, negative };
+}
+
+// Only a README that actually enumerates permissions is held to completeness. "declares" alone is far
+// too common to use as the signal — across this repo it also introduces the OpenWA version floor, a
+// hook that exists but never fires, and an allowlist host — so it counts only when a real permission
+// follows close behind. http-action names `conversation:send` while explaining which release introduced
+// the capabilities it uses; that is not an enumeration and must not be read as one.
+function enumeratesPermissions(flat) {
+  for (const m of flat.matchAll(/\b(declares?|declared|permissions:)\b/gi)) {
+    const window = flat.slice(m.index, m.index + 120);
+    if (PERMISSIONS.some((p) => window.includes('`' + p + '`'))) return true;
+  }
+  return false;
+}
+
+test("a README's permission claims match its manifest", () => {
+  // Six plugin READMEs state the declared permissions in prose, and that sentence is the only place an
+  // operator reads the list — plugins.json publishes the manifest array, but nobody browses it, and the
+  // catalog gate never opens a README's prose. Adding `storage:use` to seven manifests falsified four of
+  // those sentences at once. gsheets-logger's said "declares only `net:fetch`", which the new permission
+  // turned from stale into false; chat-flow's Security section had been contradicting itself for longer
+  // than that, claiming `messages:send` alone one sentence after describing flow state living in
+  // ctx.storage. Nothing in the toolchain would have caught any of it.
+  const problems = [];
+  for (const dir of pluginDirs) {
+    const readme = join(root, dir, 'README.md');
+    if (!existsSync(readme)) continue;
+    const flat = flatten(readFileSync(readme, 'utf8'));
+    const declared = new Set(JSON.parse(readFileSync(join(root, dir, 'manifest.json'), 'utf8')).permissions ?? []);
+    const { positive, negative } = mentionsOf(flat);
+
+    // Both directions, for every README — a stale claim is wrong whether or not the doc enumerates.
+    for (const p of positive) {
+      if (!declared.has(p)) problems.push(`${dir}: README claims \`${p}\`, manifest does not declare it`);
+    }
+    for (const p of negative) {
+      if (!positive.has(p) && declared.has(p)) {
+        problems.push(`${dir}: README says it does NOT use \`${p}\`, manifest declares it`);
+      }
+    }
+
+    // Completeness applies only where the README enumerates: a plugin is free not to list permissions
+    // at all (chatwoot-adapter and voice-transcription don't), and requiring the section would make this
+    // a documentation mandate rather than a drift guard.
+    if (!enumeratesPermissions(flat)) continue;
+    for (const p of declared) {
+      if (!positive.has(p)) problems.push(`${dir}: manifest declares \`${p}\`, README's permission list omits it`);
+    }
+  }
+  assert.deepEqual(problems, []);
+});


### PR DESCRIPTION
## What

Extends `scripts/readme-claims.test.mjs` so a README that states which permissions a plugin declares is checked against the manifest. No plugin code, no manifests, no release.

## Why

Six plugin READMEs enumerate the declared permissions in prose. That sentence is the only place most operators read the list — `plugins.json` publishes the manifest array, but nobody browses it — and nothing in the toolchain compared the two. `readme-claims.test.mjs` already guards two other claim types that drifted before (the `/api` prefix on gateway URLs, the stated OpenWA version floor), and `catalog.mjs` never opens a README's prose.

Adding `storage:use` to seven manifests falsified four of those sentences in one batch:

- `gsheets-logger` said "declares **only** `net:fetch`" — the new permission turned it from stale into false.
- `chat-flow` said "declares only `messages:send`" in two places, one of them a single sentence after "Flow state lives in `ctx.storage`". That contradiction predates this batch; both halves read plausibly on their own, which is why it survived.
- `group-translate` and `typebot-connector` carried incomplete lists.

## What is checked

Three directions, against whitespace-flattened text because these claims routinely wrap across lines (`group-translate` ends a line on "Declares" and opens the next with the list):

1. **Every permission a README claims must be declared** — catches a claim left behind by a removed permission. `supabase-otp-hook` really did drop `engine:read` in 0.3.0.
2. **Every declared permission must appear where a README enumerates them** — the defect above.
3. **A negated mention is held to the opposite direction.** `supabase-otp-hook` says "…so no `engine:read`". Rather than special-casing it out, that becomes a live guard: if `engine:read` ever returns to the manifest, the test fires.

## Two deliberate limits

**Completeness applies only where a README enumerates.** `chatwoot-adapter` and `voice-transcription` list no permissions at all, and that is allowed — requiring the section would turn a drift guard into a documentation mandate.

**"declares" alone is not the signal.** Across this repo it also introduces the version floor, a hook that exists but never fires, and an allowlist host. It counts only when a real permission token follows close behind, so `http-action` naming `conversation:send` while explaining which release introduced the capabilities it uses is correctly not read as an enumeration.

Negation detection is one word wide on purpose. Widening it to a phrase would swallow the "no" in "makes no outbound network calls and declares only `messages:send`" and invert a true claim into a false failure.

## Verification

Green on a correct tree proves nothing, so the gate was driven red first. Four mutations, each applied, tested, and reverted:

| Mutation | Result |
| --- | --- |
| `faq-bot` manifest gains `engine:read`, README list unchanged | fails: "manifest declares `engine:read`, README's permission list omits it" |
| `chat-flow` manifest drops `storage:use`, README still claims it | fails: "README claims `storage:use`, manifest does not declare it" |
| `supabase-otp-hook` manifest gains the `engine:read` its README negates | fails: "README says it does NOT use `engine:read`, manifest declares it" |
| `gsheets-logger` README restored to its pre-fix "declares only `net:fetch`" wording | fails: "manifest declares `storage:use`, README's permission list omits it" |

The last one is the actual defect from this morning: with this gate in place it would have been caught before the release rather than after.

```
tsc --noEmit             0 errors
npm test                 551/551 pass, 0 fail   (was 550)
npm run catalog:check    up to date (10 plugins)
```