### PR TITLE
fix(test): close two blind spots in the permission-claim gate

### DIFF
--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -53,7 +53,22 @@ test("each plugin README's stated OpenWA floor matches its manifest", () => {
 
 // The five permissions the host enforces at the capability boundary, plus `storage:use` — the sixth,
 // added when OpenWA moved ctx.storage behind a declaration gate.
-const PERMISSIONS = ['messages:send', 'engine:read', 'net:fetch', 'conversation:send', 'webhook:ingress', 'storage:use'];
+const KNOWN_PERMISSIONS = ['messages:send', 'engine:read', 'net:fetch', 'conversation:send', 'webhook:ingress', 'storage:use'];
+
+// The vocabulary must include anything a manifest actually declares, not just the names known when this
+// was written. Hardcoding the list alone fails in both directions the moment a plugin adopts a newer
+// permission — `search:provide` is the one waiting to happen, required by core since 0.12.2. A README
+// claiming an unlisted permission would go unseen, and worse, declaring one would report "README's
+// permission list omits it" even when the README lists it plainly, because the scan could not see the
+// name it was looking for. That failure has no fix except deleting the documentation, which is the
+// opposite of the point. Keep the known names as a floor so a permission NOBODY declares can still be
+// recognised when a README negates it.
+const PERMISSIONS = [
+  ...new Set([
+    ...KNOWN_PERMISSIONS,
+    ...pluginDirs.flatMap((d) => JSON.parse(readFileSync(join(root, d, 'manifest.json'), 'utf8')).permissions ?? []),
+  ]),
+];
 
 // Prose wraps, so a claim and the permissions it names routinely straddle a newline: group-translate
 // ends a line on "Declares" and opens the next with the list, and chat-flow splits `messages:send` from
@@ -63,12 +78,14 @@ const flatten = (text) => text.replace(/\s+/g, ' ');
 // Classify every `permission` occurrence. A negation sitting directly in front of one ("…so no
 // `engine:read`") is a claim too — the opposite one — so it is checked in the opposite direction rather
 // than skipped. The adjacency is deliberately one word: widening it to a phrase would swallow the "no"
-// in "makes no outbound network calls and declares only `messages:send`" and invert a true claim.
+// in "makes no outbound network calls and declares only `messages:send`" and invert a true claim. The
+// preceding token may not carry sentence-ending punctuation, so a question answered "No." before a
+// positive mention is not read as negating it.
 function mentionsOf(flat) {
   const positive = new Set();
   const negative = new Set();
   for (const p of PERMISSIONS) {
-    for (const m of flat.matchAll(new RegExp('(\\S+ )?`' + p + '`', 'g'))) {
+    for (const m of flat.matchAll(new RegExp('([^\\s.!?;:]+ )?`' + p + '`', 'g'))) {
       const prev = (m[1] ?? '').toLowerCase().replace(/[^a-z]/g, '');
       (prev === 'no' || prev === 'not' || prev === 'never' ? negative : positive).add(p);
     }
@@ -81,8 +98,14 @@ function mentionsOf(flat) {
 // hook that exists but never fires, and an allowlist host — so it counts only when a real permission
 // follows close behind. http-action names `conversation:send` while explaining which release introduced
 // the capabilities it uses; that is not an enumeration and must not be read as one.
+//
+// The `permissions:` marker must NOT carry a trailing \b. A word boundary after the colon needs a word
+// character next, and every real heading writes "Permissions: `webhook:ingress`" with a space — so the
+// alternative matched nothing but the impossible "permissions:x". supabase-otp-hook is the only plugin
+// that heads its list this way and uses no form of "declare", so it was the one README silently exempt
+// from the completeness check this function exists to apply.
 function enumeratesPermissions(flat) {
-  for (const m of flat.matchAll(/\b(declares?|declared|permissions:)\b/gi)) {
+  for (const m of flat.matchAll(/\b(?:declares?|declared)\b|\bpermissions?\s*:/gi)) {
     const window = flat.slice(m.index, m.index + 120);
     if (PERMISSIONS.some((p) => window.includes('`' + p + '`'))) return true;
   }
@@ -90,13 +113,22 @@ function enumeratesPermissions(flat) {
 }
 
 test("a README's permission claims match its manifest", () => {
-  // Six plugin READMEs state the declared permissions in prose, and that sentence is the only place an
+  // Seven plugin READMEs state the declared permissions in prose, and that sentence is the only place an
   // operator reads the list — plugins.json publishes the manifest array, but nobody browses it, and the
   // catalog gate never opens a README's prose. Adding `storage:use` to seven manifests falsified four of
   // those sentences at once. gsheets-logger's said "declares only `net:fetch`", which the new permission
   // turned from stale into false; chat-flow's Security section had been contradicting itself for longer
   // than that, claiming `messages:send` alone one sentence after describing flow state living in
   // ctx.storage. Nothing in the toolchain would have caught any of it.
+  //
+  // Known limits, so the next reader knows where the edge is rather than trusting past it. This matches
+  // prose, and only prose that names a permission in backticks: an enumeration written as a table, or
+  // one whose permissions sit more than ~120 characters from the word that introduces them, is not
+  // recognised as an enumeration and escapes the completeness direction. Completeness is also measured
+  // against the whole file, so a closed "declares only X" sentence can go stale while passing, if the
+  // missing permission happens to be named elsewhere in the same README. Widening any of these means
+  // parsing English, which costs more than the drift it would catch — but none of them is a reason to
+  // read a green run as "every sentence in this README is true".
   const problems = [];
   for (const dir of pluginDirs) {
     const readme = join(root, dir, 'README.md');
@@ -106,8 +138,17 @@ test("a README's permission claims match its manifest", () => {
     const { positive, negative } = mentionsOf(flat);
 
     // Both directions, for every README — a stale claim is wrong whether or not the doc enumerates.
+    // The message names the second possible cause on purpose: an unrecognised negation surfaces here,
+    // and "README claims X" alone would read as an instruction to add X to the manifest, which is the
+    // one repair that turns a documentation slip into a real over-declaration.
     for (const p of positive) {
-      if (!declared.has(p)) problems.push(`${dir}: README claims \`${p}\`, manifest does not declare it`);
+      if (!declared.has(p)) {
+        problems.push(
+          `${dir}: README names \`${p}\` as a permission this plugin has, but the manifest does not ` +
+            `declare it — either the claim is stale, or it is a denial phrased in a way this check does ` +
+            `not recognise (it reads only "no"/"not"/"never" immediately before the name)`,
+        );
+      }
     }
     for (const p of negative) {
       if (!positive.has(p) && declared.has(p)) {


### PR DESCRIPTION
## What

Two defects in the permission-claim gate added in #83, plus two smaller robustness fixes. Test-only — no manifests, no plugin code, no release.

## How they were found

By adversarially reviewing the gate against the real corpus instead of re-running it. A gate that is green on a correct tree tells you nothing about what it would miss, and both of these were exactly that: silently weaker than the code reads.

## Defect 1 — the `permissions:` marker never matched anything

`/\b(declares?|declared|permissions:)\b/gi`. The trailing `\b` after the colon requires a word character next; every real heading writes `Permissions: ` with a space. The alternative could only ever match the impossible `permissions:x`.

`supabase-otp-hook` heads its list that way and contains no form of "declare", so it was the one plugin README fully exempt from the completeness direction. Reproduced end to end: adding `storage:use` to its manifest leaves the README asserting a closed list of two permissions, and the suite stays green.

The tell was in the comment I wrote — "Six plugin READMEs state the declared permissions in prose". There are seven. The dead branch dropped exactly the one that was miscounted.

## Defect 2 — the permission vocabulary was hardcoded

`PERMISSIONS` was a fixed six. Any permission outside it was invisible to `mentionsOf`, which has two faces, and the second is worse than a miss:

- **Silent:** a README claiming an unlisted permission is never checked against the manifest.
- **Unfixable false failure:** declaring one reports ``manifest declares `search:provide`, README's permission list omits it`` *even when the README lists it plainly* — because the scan cannot see the name it is searching for. The only way to green the suite would be to delete the documentation, which inverts the point of the gate.

`search:provide` is the case waiting to happen: core has required it since 0.12.2 and the vendored contract documents it. The vocabulary is now the union of the known names and every permission the manifests actually declare, so it grows with the repo. The known names stay as a floor, so a permission nobody declares can still be recognised when a README negates it.

## Two smaller fixes

**Sentence boundaries.** The preceding-token capture accepted any non-space characters, so `Does it keep the audio? No. \`storage:use\` holds a dedup marker` read "No." as negating a positive mention. The capture now rejects sentence-ending punctuation.

**A misleading failure message.** ``README claims `engine:read`, manifest does not declare it`` reads as an instruction to add the permission to the manifest — the one repair that turns a documentation slip into a real over-declaration. Since an unrecognised negation surfaces through this same path, the message now names both causes.

## Known limits, now written down

The gate matches prose, and only prose naming a permission in backticks. A table-shaped enumeration, or one whose permissions sit more than ~120 characters from the word introducing them, is not recognised as an enumeration. Completeness is measured against the whole file, so a closed "declares only X" sentence can go stale while passing if the missing name appears elsewhere in the same README.

None of these is fixed here. Closing them means parsing English, which costs more than the drift it would catch — but leaving them undocumented invites reading a green run as "every sentence in this README is true", so they are now stated in the test.

## Verification

Nine scenarios, each applied to the working tree, tested, and reverted:

| Scenario | Want | Got |
| --- | --- | --- |
| manifest gains a permission the README list omits | RED | RED |
| README claims a permission the manifest dropped | RED | RED |
| negated mention, manifest adds it anyway | RED | RED |
| the real gsheets-logger bug, pre-fix wording | RED | RED |
| **`Permissions:` heading, manifest gains a permission** | **RED** | **RED** |
| **out-of-list permission that IS documented** | **GREEN** | **GREEN** |
| **out-of-list permission NOT documented** | **RED** | **RED** |
| **sentence-boundary "No." before a positive mention** | **GREEN** | **GREEN** |
| untouched tree | GREEN | GREEN |

The three GREEN rows matter as much as the red ones: a gate that fails on correct documentation gets worked around rather than obeyed.

```
tsc --noEmit             0 errors
npm test                 551/551 pass, 0 fail
npm run catalog:check    up to date (10 plugins)
```