### PR TITLE
fix(test): check the README claim shapes the corpus actually uses

### DIFF
--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -17,6 +17,17 @@ const pluginDirs = readdirSync(root, { withFileTypes: true })
 
 const readmes = [join(root, 'README.md'), ...pluginDirs.map(d => join(root, d, 'README.md'))].filter(existsSync);
 
+// Prose wraps, so a claim and the value it states routinely straddle a newline: group-translate ends a
+// line on "Declares" and opens the next with the list, and gsheets-logger splits "Requires OpenWA" from
+// "**≥ 0.7.0**" the same way. Anything matched across a claim has to be matched on flattened text.
+const flatten = (text) => text.replace(/\s+/g, ' ');
+
+// The placeholder hosts a README uses for the gateway itself. Anything else in these documents is a
+// third-party backend — LibreTranslate, an ERP, a Speaches STT, an n8n webhook — and must not be held to
+// the gateway's `/api` prefix. That is why loopback is listed WITH the gateway port: a bare 127.0.0.1
+// would sweep in `http://127.0.0.1:8000` (STT) and `http://127.0.0.1:5678/webhook/transcript` (n8n).
+const GATEWAY_HOSTS = /your-openwa-host|localhost:2785|127\.0\.0\.1:2785|<host>/;
+
 test('every gateway URL in a README carries the /api prefix', () => {
   // The gateway mounts a global `/api` prefix, so `<host>/plugins/...` answers 404. 27 copy-pasteable
   // curl commands addressed it without the prefix.
@@ -25,7 +36,7 @@ test('every gateway URL in a README carries the /api prefix', () => {
     const text = readFileSync(file, 'utf8');
     for (const m of text.matchAll(/https?:\/\/[^\s'"`)]+/g)) {
       const url = m[0];
-      if (!/your-openwa-host|localhost:2785/.test(url)) continue;
+      if (!GATEWAY_HOSTS.test(url)) continue;
       const path = url.replace(/^https?:\/\/[^/]+/, '');
       if (path && path !== '/' && !path.startsWith('/api/')) offenders.push(`${file.replace(root + '/', '')}: ${url}`);
     }
@@ -43,9 +54,26 @@ test("each plugin README's stated OpenWA floor matches its manifest", () => {
     const declared = JSON.parse(readFileSync(join(root, dir, 'manifest.json'), 'utf8')).minOpenWAVersion;
     if (!declared) continue;
     const text = readFileSync(readme, 'utf8');
+    const flat = flatten(text);
     const stated = new Set();
     for (const m of text.matchAll(/badge\/OpenWA-%E2%89%A5%20([0-9.]+)-/g)) stated.add(m[1]);
-    for (const m of text.matchAll(/OpenWA\s*\*\*≥\s*([0-9.]+)\*\*/g)) stated.add(m[1]);
+    // Only PLUGIN-level floors. These READMEs also state per-feature floors — gsheets-logger's ack rows
+    // need 0.6.1, chatwoot-adapter's attachment backfill needs 0.8.6 — and those are legitimately
+    // different numbers from the manifest, so comparing them would fail correct documentation.
+    //
+    // The corpus separates the two by capitalisation, and it does so consistently: a plugin-level claim
+    // opens a sentence ("Targets OpenWA…", "Requires OpenWA…", "Have OpenWA…") or heads a Compatibility
+    // bullet as bold **OpenWA**, while a per-feature floor sits mid-sentence behind a lowercase verb
+    // ("…rows** require OpenWA ≥ v0.6.1", "Needs OpenWA 0.8.6+"). So the lead-ins are matched
+    // case-SENSITIVELY on purpose — the capital is the signal, not an accident of style.
+    //
+    // Until now only the `OpenWA **≥ x**` shape was matched at all, and it escaped the ack-row sentence
+    // purely because that one writes `v0.6.1` with a v. Dropping the v would have turned correct prose
+    // into a failure; the two plugins with the HIGHEST floors, chatwoot-adapter and supabase-otp-hook,
+    // meanwhile stated theirs in shapes nothing looked at.
+    for (const m of flat.matchAll(/(?:Targets|Requires|Have) OpenWA\s*\*\*≥\s*v?([0-9.]+)\*\*/g)) stated.add(m[1]);
+    for (const m of flat.matchAll(/(?:Targets|Requires|Have) OpenWA\s+v?([0-9.]+)\+/g)) stated.add(m[1]);
+    for (const m of flat.matchAll(/\*\*OpenWA\*\*\s*≥\s*v?([0-9.]+)/g)) stated.add(m[1]);
     for (const v of stated) if (v !== declared) mismatches.push(`${dir}: README says ${v}, manifest says ${declared}`);
   }
   assert.deepEqual(mismatches, []);
@@ -69,11 +97,6 @@ const PERMISSIONS = [
     ...pluginDirs.flatMap((d) => JSON.parse(readFileSync(join(root, d, 'manifest.json'), 'utf8')).permissions ?? []),
   ]),
 ];
-
-// Prose wraps, so a claim and the permissions it names routinely straddle a newline: group-translate
-// ends a line on "Declares" and opens the next with the list, and chat-flow splits `messages:send` from
-// `storage:use` the same way. Anything matched across a claim has to be matched on flattened text.
-const flatten = (text) => text.replace(/\s+/g, ' ');
 
 // Classify every `permission` occurrence. A negation sitting directly in front of one ("…so no
 // `engine:read`") is a claim too — the opposite one — so it is checked in the opposite direction rather


### PR DESCRIPTION
## What

Closes two pre-existing gaps in `scripts/readme-claims.test.mjs`. Both were silent, and both were found while reviewing the permission gate rather than by anything failing. Test-only — no manifests, no plugin code, no release.

## Gap 1 — the OpenWA floor check knew one shape out of three

It matched `OpenWA **≥ x.y.z**`. The corpus writes plugin floors three ways, and the two it missed are exactly the ones that matter most:

| Shape | Where | Checked before |
| --- | --- | --- |
| `Targets/Have OpenWA **≥ x**` | six plugins | yes |
| `- **OpenWA** ≥ 0.8.7` | chatwoot-adapter, supabase-otp-hook | **no** |
| `Requires OpenWA v0.8.16+` | supabase-otp-hook | **no** |

So the two plugins with the highest floors — the ones where a wrong number does the most damage — had hand-maintained prose floors that nothing verified. That is the same defect class the test was written for after `after-hours` carried 0.6.2 in prose against a 0.7.0 manifest.

**Widening it is where the care goes.** These READMEs also state *per-feature* floors that legitimately differ from the manifest: gsheets-logger's `message:ack` rows need 0.6.1 against a 0.7.0 manifest, chatwoot-adapter's attachment backfill needs 0.8.6 against 0.8.7. The old pattern skipped the ack-row sentence only by accident — it writes `v0.6.1` with a `v`, and the pattern wanted a digit. Normalising that `v` away would have turned correct documentation into a build failure.

The corpus separates the two kinds consistently, by capitalisation: a plugin-level claim opens a sentence (`Targets`, `Requires`, `Have`) or heads a Compatibility bullet as bold `**OpenWA**`; a per-feature floor sits mid-sentence behind a lowercase verb (`…rows** require OpenWA`, `Needs OpenWA`). The lead-ins are matched **case-sensitively** for that reason — the capital is the signal, not an accident of style. Matching runs on flattened text because gsheets-logger wraps `Requires OpenWA` onto the line before its version.

## Gap 2 — the /api check only looked at two placeholder hosts

The filter was `your-openwa-host|localhost:2785`. supabase-otp-hook documents its ingress endpoint as `https://<host>/api/ingress/supabase-otp-hook/default/send-sms` — the one gateway URL in the repo on a different placeholder, and never inspected. Drop its `/api` and nothing notices.

Loopback is added **with the gateway port**, not bare. A bare `127.0.0.1` would sweep in `http://127.0.0.1:8000` (a self-hosted Speaches STT) and `http://127.0.0.1:5678/webhook/transcript` (an n8n receiver) — third-party services that must not carry `/api`, and flagging them would train people to ignore the check.

## Verification

Nine scenarios, each applied, tested, and reverted. The GREEN rows are the point: a looser pattern is only an improvement if it still ignores what it should.

| Scenario | Want | Got |
| --- | --- | --- |
| `- **OpenWA** ≥ x` floor drifts from manifest | RED | RED |
| `Requires OpenWA vX+` floor drifts from manifest | RED | RED |
| `<host>` gateway URL loses its `/api` prefix | RED | RED |
| per-feature floor written without the `v` (0.6.1 vs 0.7.0 manifest) | GREEN | GREEN |
| per-feature floor as `Needs OpenWA **≥ 0.8.6**` (vs 0.8.7 manifest) | GREEN | GREEN |
| third-party loopback backend on a non-`/api` path | GREEN | GREEN |
| plugin-level floor drift still caught | RED | RED |
| `your-openwa-host` missing `/api` still caught | RED | RED |
| untouched tree | GREEN | GREEN |

The nine scenarios covering the permission gate were re-run unchanged — no regression from moving `flatten` above the tests or from the shared `GATEWAY_HOSTS` constant.

```
tsc --noEmit             0 errors
npm test                 551/551 pass, 0 fail
npm run catalog:check    up to date (10 plugins)
```