### PR TITLE
docs(supabase-otp-hook): point the install download at the repo that has releases

### DIFF
--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -44,6 +44,29 @@ test('every gateway URL in a README carries the /api prefix', () => {
   assert.deepEqual(offenders, []);
 });
 
+test("a plugin README links the repository its manifest names", () => {
+  // supabase-otp-hook was contributed from another account, and its Install section pointed at that
+  // account's fork for the download. PR #54 corrected `repository` in the manifest — which is what the
+  // catalog derives release URLs from — but the README sentence was missed, so the documented path stayed
+  // a fork with zero releases: a page that opens, looks right, and offers nothing. That is the same shape
+  // as the permission drift this file already guards, and the second time here that a manifest was fixed
+  // while the prose describing it was not.
+  //
+  // `author` deliberately keeps the original contributor and is not a URL, so it is untouched by this.
+  const wrong = [];
+  for (const dir of pluginDirs) {
+    const readme = join(root, dir, 'README.md');
+    if (!existsSync(readme)) continue;
+    const repo = JSON.parse(readFileSync(join(root, dir, 'manifest.json'), 'utf8')).repository;
+    const owner = repo?.match(/github\.com\/([\w.-]+)\//)?.[1];
+    if (!owner) continue;
+    for (const m of readFileSync(readme, 'utf8').matchAll(/([\w.-]+)\/OpenWA-plugins/g)) {
+      if (m[1] !== owner) wrong.push(`${dir}: README links ${m[1]}/OpenWA-plugins, manifest repository is ${owner}`);
+    }
+  }
+  assert.deepEqual([...new Set(wrong)], []);
+});
+
 test("each plugin README's stated OpenWA floor matches its manifest", () => {
   // after-hours carried a hand-maintained badge and two prose mentions saying 0.6.2 while the manifest
   // declared 0.7.0 — three numbers, one of them the one the catalog actually publishes.

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -118,7 +118,7 @@ curl -X PATCH "$OPENWA/api/integration/plugins/supabase-otp-hook/instances/defau
 
 ## Install
 
-**Option A — dashboard.** Download `supabase-otp-hook.zip` from the [Releases page](https://github.com/maplerichie/OpenWA-plugins/releases), then dashboard → Plugins → Install → upload.
+**Option A — dashboard.** Download `supabase-otp-hook.zip` from the [Releases page](https://github.com/rmyndharis/OpenWA-plugins/releases), then dashboard → Plugins → Install → upload.
 
 **Option B — CLI.**
 


### PR DESCRIPTION
## What

Fixes the Install → Option A download link, and adds a guard so a plugin README cannot link an owner its manifest does not name. Documentation and test only — no manifest, no version, no release.

## Why

`supabase-otp-hook`'s README told users:

> **Option A — dashboard.** Download `supabase-otp-hook.zip` from the [Releases page](https://github.com/maplerichie/OpenWA-plugins/releases)…

That fork exists and answers HTTP 200, and it has **zero releases**. The correct repo has 90. So the first install path the README recommends leads to a page that opens, looks legitimate, and offers nothing to download — which is harder to diagnose than a 404.

PR #54 already corrected `repository` in the manifest, which is what `catalog.mjs` derives every release URL from, so `plugins.json` and the dashboard Catalog tab were never affected. Only this sentence was missed.

## The pattern, and the guard

This is the second time in this repo that a manifest was fixed while the prose describing it was not — the first was the permission lists, which now have a gate. Nothing checked repository links either.

The new check ties each plugin README's `<owner>/OpenWA-plugins` links to the owner in its own `manifest.repository`. It generalises instead of hardcoding `rmyndharis`, so a plugin legitimately hosted elsewhere would be held to *its* manifest rather than to this repo's owner.

`author` deliberately keeps the original contributor (`maplerichie`) and is not a URL, so it is untouched — the credit stays, only the broken download path changes.

## Verification

Red before green: restoring the fork URL fails with

```
supabase-otp-hook: README links maplerichie/OpenWA-plugins, manifest repository is rmyndharis
```

Nine of the ten plugin READMEs were already consistent, so the new check passes on them unchanged — this was the only offender.

The eighteen scenarios covering the permission gate and the floor/`/api` checks were re-run with no change in behaviour.

```
tsc --noEmit             0 errors
npm test                 552/552 pass, 0 fail   (was 551)
npm run catalog:check    up to date (10 plugins)
```