### PR TITLE
docs: align the plugin contract with the storage gate OpenWA now enforces

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ my-plugin/
   "type": "extension",          // only "extension" is user-installable
   "main": "dist/index.js",      // require()-able file inside the package
   "description": "…",
-  "permissions": ["messages:send"],   // enforced gates: messages:send · engine:read · net:fetch · webhook:ingress · conversation:send
+  "permissions": ["messages:send"],   // enforced gates: messages:send · engine:read · net:fetch · webhook:ingress · conversation:send · storage:use · search:provide
   "sessions": ["*"],                   // session-id scope; omit ⇒ all sessions
   "hooks": ["message:received"],       // declared interest (informational)
   "configSchema": {                    // drives the dashboard settings form
@@ -204,7 +204,7 @@ React to activity with `ctx.registerHook(event, handler, priority?)`. Handlers a
 
 ### Capabilities
 
-The `PluginContext` exposes a deliberately small surface. The two action capabilities are gated by `manifest.permissions` — calling one you didn't declare throws `PluginCapabilityError`.
+The `PluginContext` exposes a deliberately small surface. Every capability below with a permission in the last column is gated by `manifest.permissions` — calling one you didn't declare throws `PluginCapabilityError`, at the call rather than at load, so an undeclared capability fails mid-run and not at install.
 
 | Capability | Methods | Permission |
 | ---------- | ------- | ---------- |
@@ -215,10 +215,20 @@ The `PluginContext` exposes a deliberately small surface. The two action capabil
 | `ctx.handover` | `set(…, state)` — bot/human/closed handover for a mapped chat (v1) | `conversation:send` |
 | `ctx.mappings` | `upsert` · `get` · `getByProvider` — WA-chat ↔ provider-conversation mapping (v1) | `conversation:send` |
 | `ctx.registerWebhook` | claim an inbound ingress route (v1) | `webhook:ingress` |
-| `ctx.storage` | `get` · `set` · `delete` · `list` (namespaced per plugin) | — |
+| `ctx.storage` | `get` · `set` · `delete` · `list` (namespaced per plugin) | `storage:use` |
 | `ctx.logger` | `log` · `debug` · `warn` · `error` | — |
 
-Also available: `ctx.config`, `ctx.manifest`, `ctx.pluginId`, `ctx.registerHook`, `ctx.hookManager`.
+Also available: `ctx.config`, `ctx.pluginId`, `ctx.registerHook`.
+
+> `ctx.storage` was ungated until OpenWA moved it behind `storage:use`. A plugin that persists anything
+> should declare it now rather than when its host is upgraded: an older host ignores an unrecognized
+> permission, so the declaration is free, and a newer one denies the call — mid-conversation, because
+> permissions are checked at the call and not at load.
+>
+> There is no `ctx.manifest` and no `ctx.hookManager` on the sandboxed context the worker builds, so
+> reading `ctx.manifest.version` typechecks against a stale copy of the vendored types and throws at
+> runtime. To know your own version, bake it in at build time (see `package.mjs`, which defines
+> `__PLUGIN_VERSION__` from the manifest).
 
 ### Constraints to design around
 

--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -40,13 +40,20 @@ const GATEWAY_HOSTS = /your-openwa-host|localhost:2785|127\.0\.0\.1:2785|<host>/
 //
 // Shared with the precondition test, which asserts the result is non-empty. Without that, a README
 // wording its floor in none of these shapes makes the comparison pass while comparing nothing.
+// A dotted version, bounded so it cannot swallow the punctuation that follows it. `[0-9.]+` is the
+// tempting spelling and it is wrong on the one pattern below that has no terminator: "**OpenWA** ≥
+// 0.8.7." at the end of a sentence captures "0.8.7." and reports a mismatch against a manifest that
+// says "0.8.7". The three terminated patterns happen to be safe, but they are written this way too so
+// the next pattern copied from them inherits the bounded form rather than the hazard.
+const VER = '(\\d+(?:\\.\\d+)*)';
+
 function statedFloors(text) {
   const flat = flatten(text);
   const stated = new Set();
-  for (const m of text.matchAll(/badge\/OpenWA-%E2%89%A5%20([0-9.]+)-/g)) stated.add(m[1]);
-  for (const m of flat.matchAll(/(?:Targets|Requires|Have) OpenWA\s*\*\*≥\s*v?([0-9.]+)\*\*/g)) stated.add(m[1]);
-  for (const m of flat.matchAll(/(?:Targets|Requires|Have) OpenWA\s+v?([0-9.]+)\+/g)) stated.add(m[1]);
-  for (const m of flat.matchAll(/\*\*OpenWA\*\*\s*≥\s*v?([0-9.]+)/g)) stated.add(m[1]);
+  for (const m of text.matchAll(new RegExp(`badge/OpenWA-%E2%89%A5%20${VER}-`, 'g'))) stated.add(m[1]);
+  for (const m of flat.matchAll(new RegExp(`(?:Targets|Requires|Have) OpenWA\\s*\\*\\*≥\\s*v?${VER}\\*\\*`, 'g'))) stated.add(m[1]);
+  for (const m of flat.matchAll(new RegExp(`(?:Targets|Requires|Have) OpenWA\\s+v?${VER}\\+`, 'g'))) stated.add(m[1]);
+  for (const m of flat.matchAll(new RegExp(`\\*\\*OpenWA\\*\\*\\s*≥\\s*v?${VER}`, 'g'))) stated.add(m[1]);
   return stated;
 }
 
@@ -186,11 +193,17 @@ const PERMISSIONS = [
 // in "makes no outbound network calls and declares only `messages:send`" and invert a true claim. The
 // preceding token may not carry sentence-ending punctuation, so a question answered "No." before a
 // positive mention is not read as negating it.
+// PERMISSIONS is no longer a fixed list of safe literals — it absorbs whatever the manifests declare,
+// so a name is untrusted input to the regex built from it. An unescaped `weird:a(b` does not mis-match,
+// it throws "Invalid regular expression: Unterminated group" and takes the whole file down with a
+// SyntaxError instead of a named failure.
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 function mentionsOf(flat) {
   const positive = new Set();
   const negative = new Set();
   for (const p of PERMISSIONS) {
-    for (const m of flat.matchAll(new RegExp('([^\\s.!?;:]+ )?`' + p + '`', 'g'))) {
+    for (const m of flat.matchAll(new RegExp('([^\\s.!?;:]+ )?`' + escapeRe(p) + '`', 'g'))) {
       const prev = (m[1] ?? '').toLowerCase().replace(/[^a-z]/g, '');
       (prev === 'no' || prev === 'not' || prev === 'never' ? negative : positive).add(p);
     }

--- a/types/openwa.d.ts
+++ b/types/openwa.d.ts
@@ -82,8 +82,13 @@ export interface PluginLogger {
 }
 
 /**
- * Per-plugin key/value storage. Needs no manifest permission. One JSON file per key under
- * `<dataDir>/plugins/<pluginId>/`, so key COUNT is a real cost, not just key size:
+ * Per-plugin key/value storage. Needs the "storage:use" permission — all four verbs assert it, so an
+ * undeclared plugin is denied at the first call rather than at load. It was ungated until OpenWA gated
+ * it (core `plugin-capability-context.ts` `buildStorageCapability`); declaring it is inert on an older
+ * host, which is why a plugin should declare it now rather than when its host is upgraded.
+ *
+ * One JSON file per key under `<dataDir>/plugins/<pluginId>/`, so key COUNT is a real cost, not just
+ * key size:
  *
  * - `set` REJECTS once the plugin's directory would exceed 50 MiB ("storage quota exceeded"), and the
  *   quota is measured by a synchronous readdir + stat of every key on EVERY write. A plugin that
@@ -255,6 +260,7 @@ export interface PluginContext {
   /** The RESOLVED config for `sessionId` (the per-session slice merged over the "*" defaults). */
   config: Record<string, unknown>;
   logger: PluginLogger;
+  /** Per-plugin key/value store (needs the "storage:use" permission — see PluginStorage). */
   storage: PluginStorage;
   registerHook(event: HookEvent, handler: HookHandler, priority?: number): void;
   messages: PluginMessagingCapability;


### PR DESCRIPTION
## What

OpenWA merged the change that puts `ctx.storage` behind a declared `storage:use` permission. This repo's contract documentation still described the old behaviour. Four statements corrected, plus two defects in the checks. Documentation and test only — **no plugin needs a release**; none of these files is in a packaged `.zip` or in `plugins.json`.

## Why now

The gate is live, not pending:

```
plugin.interfaces.ts            STORAGE_USE: 'storage:use'
plugin-capability-context.ts    :184  storage: this.buildStorageCapability(plugin)
                                :292  gate() = assertPermission(…, STORAGE_USE) on every verb
```

The seven plugin releases that declared it are therefore correctly ahead of it, and no installed plugin in this catalog is affected. What is affected is anyone writing a *new* plugin from our documentation.

## The contradictions

| Where | Said | Reality |
| --- | --- | --- |
| `types/openwa.d.ts` `PluginStorage` | "Needs no manifest permission" | needs `storage:use`; denied at the first call |
| `README.md` manifest example | five enforced gates | seven |
| `README.md` capability table | `ctx.storage` → `—` | `storage:use` |
| `README.md` table preamble | "the two action capabilities are gated" | eight rows carry a permission |

The first one is the reason this is worth a PR rather than a note. `types/openwa.d.ts` is what plugin authors code against, and the README presents it as the contract — "accurate, code-verified documentation of the plugin contract". Following it now produces a plugin that installs cleanly, looks healthy, and is denied at its first storage call, **mid-conversation**, because permissions are checked at the call and not at load. That is the same failure shape the seven releases existed to prevent, arriving from the documentation side instead.

### A fourth, older one

The same paragraph advertised `ctx.manifest` and `ctx.hookManager`. The sandbox context builds neither — verified against `sandbox/worker-bootstrap.ts`, which assembles `pluginId`, `config`, `logger`, capabilities, `registerHook`, `registerWebhook`, `registerSearchProvider` and nothing else. `types/openwa.d.ts` has said so for a while; the README never caught up. Reading `ctx.manifest.version` typechecks against the vendored types and throws at runtime, so the note now points at the working alternative — the build defines `__PLUGIN_VERSION__` from the manifest.

## Two defects in the checks

Both were introduced along with the checks, and both are proven by driving them rather than by reading:

**`mentionsOf` could crash the whole file.** It builds a `RegExp` from each permission name. That list stopped being fixed literals when it began absorbing whatever the manifests declare, so the names became untrusted regex input:

```
before:  SyntaxError: Invalid regular expression: /([^\s.!?;:]+ )?`weird:a(b`/g: Unterminated group
after:   faq-bot: manifest declares `weird:a(b`, README's permission list omits it
```

A crash is worse than a failure here — it replaces a named problem with a stack trace, and every other check in the file stops running.

**`statedFloors` swallowed sentence punctuation.** The version was matched as `[0-9.]+`, fine on the three patterns with a terminator and wrong on the one without:

```
before:  "- **OpenWA** ≥ 0.8.7. Needs …"  →  chatwoot-adapter: README says 0.8.7., manifest says 0.8.7
after:   passes; and "≥ 0.8.2" against a 0.8.7 manifest still fails correctly
```

All four patterns now share a bounded version fragment, so the next pattern copied from them inherits the bounded form rather than the hazard.

## Verification

```
tsc --noEmit             0 errors
npm test                 553/553 pass, 0 fail
npm run catalog:check    up to date (10 plugins)

regression, all four earlier proof suites re-run unchanged:
  permission gate scenarios      0 wrong
  floor / api gap scenarios      0 wrong
  precondition scenarios         0 wrong
  vacuous-pass scenarios         0 wrong
```

Both fixes were checked in both directions — the defect gone, and the coverage it protects still firing.