### PR TITLE
fix: close the six gaps the pre-release review left open

### DIFF
--- a/PLUGIN-STANDARD.md
+++ b/PLUGIN-STANDARD.md
@@ -1,8 +1,10 @@
 # OpenWA Plugin Standard
 
 The conventions every plugin in this repository follows, so the catalog stays consistent and
-management/automation stays easy. Verified against OpenWA's plugin runtime (sandboxed worker model,
-v0.7.x).
+management/automation stays easy. Verified against OpenWA's plugin runtime (sandboxed worker model) at
+the same baseline as [`types/openwa.d.ts`](./types/openwa.d.ts) — re-check both together, since this
+document describes host behaviour that has moved repeatedly (per-session config in 0.7, boot re-enable
+and the storage quota in 0.12, the `storage:use` gate after 0.16).
 
 ## Principles
 
@@ -292,7 +294,9 @@ correct plugins and were each learned the hard way. Re-verify against OpenWA cor
    `require('fs')`/`('net')`/`('child_process')`; what the worker actually buys you is a 256 MB heap
    ceiling and a crash that doesn't take the gateway down. Review submitted plugins accordingly.
 
-**Permissions** — the five values the host enforces, and what each unlocks:
+**Permissions** — the seven values the host enforces, and what each unlocks. `scripts/catalog.mjs`
+rejects a manifest declaring anything outside this set, so adopting a new one is a deliberate edit
+there rather than a silent publish into `plugins.json`:
 
 | Permission | Unlocks |
 |---|---|
@@ -301,6 +305,8 @@ correct plugins and were each learned the hard way. Re-verify against OpenWA cor
 | `net:fetch` | `ctx.net.fetch`, further scoped by manifest `net.allow` / `net.allowConfigHosts` |
 | `conversation:send` | `ctx.conversations.send` **and** `ctx.handover.set` **and** `ctx.mappings.*` |
 | `webhook:ingress` | `ctx.registerWebhook`; **required** whenever the manifest declares `ingress`, or the whole plugin fails to load |
+| `storage:use` | `ctx.storage.get` / `.set` / `.delete` / `.list`. Ungated until OpenWA gated it, so declare it as soon as a plugin persists anything: an older host ignores the unrecognized name, a newer one denies the call — and the denial lands mid-run, because permissions are checked at the call and not at load |
+| `search:provide` | `ctx.registerSearchProvider`. Not vendored in `types/openwa.d.ts` and used by no plugin here; under the default `SEARCH_PROVIDER=auto` a plugin that registers becomes the gateway's active search backend |
 
 An ingress route with `signature.scheme: "none"` is a hard load failure for the entire plugin unless the
 operator sets `ALLOW_UNSIGNED_INGRESS=true`. `mode: "sync-reply"` is inert dead code — declare
@@ -364,8 +370,9 @@ One entry per plugin, written by `scripts/catalog.mjs` from each manifest + chan
   // What the plugin DECLARES it binds — see the caveat below before treating any of it as a guarantee.
   "permissions",          // the capability permissions from the manifest
   "net",                  // the manifest `net` block, or null
-  "ingress",              // [{ route, methods, signature }] per declared ingress route, or null
-  "sessionScoped"         // whether activation is per-session
+  "ingress",              // [{ route, signature }] per declared ingress route, or null
+  "sessionScoped",        // whether activation is per-session
+  "i18n"                  // the manifest `i18n` block — emitted only when the manifest has one
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,14 +113,16 @@ All routes require an ADMIN role.
 
 | Method & path | Purpose |
 | ------------- | ------- |
-| `GET /plugins` | List installed plugins and their status |
-| `GET /plugins/:id` | Inspect one plugin (config secrets redacted) |
-| `POST /plugins/install` | Upload and install a `.zip` (multipart field `file`) |
-| `POST /plugins/:id/enable` | Run the plugin (`onLoad` → `onEnable`) |
-| `POST /plugins/:id/disable` | Stop the plugin and unregister its hooks |
-| `PUT /plugins/:id/config` | Update config (`{ "config": { ... } }`); fires `onConfigChange` if enabled |
-| `DELETE /plugins/:id` | Uninstall and remove files (built-ins are protected) |
-| `GET /plugins/:id/health` | Plugin-reported health check |
+| `GET /api/plugins` | List installed plugins and their status |
+| `GET /api/plugins/:id` | Inspect one plugin (config secrets redacted) |
+| `POST /api/plugins/install` | Upload and install a `.zip` (multipart field `file`) |
+| `POST /api/plugins/:id/enable` | Run the plugin (`onLoad` → `onEnable`) |
+| `POST /api/plugins/:id/disable` | Stop the plugin and unregister its hooks |
+| `PUT /api/plugins/:id/config` | Update config (`{ "config": { ... } }`); fires `onConfigChange` if enabled |
+| `DELETE /api/plugins/:id` | Uninstall and remove files (built-ins are protected) |
+| `GET /api/plugins/:id/health` | Plugin-reported health check |
+
+The gateway mounts every route under a global `/api` prefix, so the paths above are the complete ones — dropping it answers 404.
 
 ## Plugin contract
 
@@ -190,7 +192,7 @@ export default class MyPlugin implements IPlugin {
 | `onDisable(ctx)` | When disabled — tear down; hooks auto-unregister |
 | `onUnload(ctx)` | Before removal from memory |
 | `onConfigChange(ctx, newConfig)` | When config is updated (only while enabled) |
-| `healthCheck()` | On `GET /plugins/:id/health` |
+| `healthCheck()` | On `GET /api/plugins/:id/health` |
 
 ### Hooks
 
@@ -199,8 +201,9 @@ React to activity with `ctx.registerHook(event, handler, priority?)`. Handlers a
 | Group | Events |
 | ----- | ------ |
 | **Session** | `session:created` · `session:starting` · `session:ready` · `session:qr` · `session:disconnected` · `session:error` · `session:deleted` |
-| **Message** | `message:received` · `message:sending` · `message:sent` · `message:failed` · `message:ack` |
+| **Message** | `message:received` · `message:sending` · `message:sent` · `message:failed` · `message:ack` · `message:persisted` · `message:deleted` |
 | **Webhook** | `webhook:before` · `webhook:queued` · `webhook:delivered` · `webhook:after` · `webhook:error` |
+| **Ingress** | `ingress:error` |
 
 ### Capabilities
 

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -25,9 +25,9 @@
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->
 
-The installed version is also visible in the OpenWA dashboard Plugins list (`v0.2.3`), via
-`GET /plugins/gsheets-logger`, and at runtime in the enable log line and `healthCheck`
-(`GET /plugins/gsheets-logger/health` → `"v0.2.3 — N rows buffered"`).
+The installed version is also visible in the OpenWA dashboard Plugins list, via
+`GET /api/plugins/gsheets-logger`, and at runtime in the enable log line and `healthCheck`
+(`GET /api/plugins/gsheets-logger/health` → `"v<version> — N rows buffered"`).
 
 ## Features
 
@@ -147,7 +147,7 @@ Send yourself a WhatsApp message, then confirm the pipeline end to end:
 
 1. **Events are arriving.** Call the health endpoint:
    ```
-   GET /plugins/gsheets-logger/health   →   "v0.2.3 — N rows buffered"
+   GET /api/plugins/gsheets-logger/health   →   "v<version> — N rows buffered"
    ```
    If `N` grows, messages are reaching the plugin — the only step left is the write to Google.
 2. **Writes are succeeding.** A healthy flush logs nothing; a failed one logs
@@ -245,7 +245,7 @@ The service-account JSON is marked `secret` in the config schema, so OpenWA mask
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md). Latest: **0.2.3** (2026-07-02) — cap oversized cells, extend the formula-injection guard to `+`/`-`, floor the flush interval.
+See [CHANGELOG.md](./CHANGELOG.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "engines": { "node": ">=22" },
   "scripts": {
-    "build": "for d in */; do if [ -f \"${d}manifest.json\" ]; then node package.mjs \"${d%/}\"; fi; done",
+    "build": "set -e; for d in */; do if [ -f \"${d}manifest.json\" ]; then node package.mjs \"${d%/}\"; fi; done",
     "catalog": "node scripts/catalog.mjs",
     "catalog:check": "node scripts/catalog.mjs --check",
     "test": "node scripts/run-tests.mjs",

--- a/package.mjs
+++ b/package.mjs
@@ -78,6 +78,15 @@ function collectEntryFiles(base, rel) {
   return [{ name: rel, data: readFileSync(abs) }];
 }
 const result = entries.flatMap((entry) => collectEntryFiles(dir, entry));
+
+// The archive members are chosen here, not read from the manifest, so a `main` pointing anywhere else
+// produces a package every gate in this repo accepts and the host refuses: it rejects an archive whose
+// `main` is not among its entries, at install, after the release is already tagged and published.
+const mainInZip = join('.', manifest.main).split('\\').join('/');
+if (!result.some((f) => f.name === mainInZip)) {
+  fail(`manifest main "${manifest.main}" is not in the package (members: ${result.map((f) => f.name).join(', ')})`);
+}
+
 await writeFile(zipPath, zipStore(result));
 
 // ── Report size + sha256 (release artifacts — surfaced here and in the GitHub Release) ──

--- a/scripts/catalog.mjs
+++ b/scripts/catalog.mjs
@@ -24,6 +24,23 @@ function discoverPlugins() {
 
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'it', 'ar', 'he', 'te', 'zh-CN', 'zh-HK'];
 
+// Every permission the host actually enforces (core `PluginCapabilityPermission`). Nothing else in the
+// toolchain looked at these names: the array was passed straight through to plugins.json, which is what
+// the in-dashboard marketplace reads, so an invented or misspelled one was published verbatim and only
+// discovered when the capability it was meant to unlock silently failed at runtime.
+//
+// A closed list makes adopting a genuinely new permission a deliberate one-line edit here — which is the
+// point. `storage:use` reached seven manifests without anything in this repo ever checking the name.
+const HOST_PERMISSIONS = new Set([
+  'messages:send',
+  'engine:read',
+  'net:fetch',
+  'storage:use',
+  'webhook:ingress',
+  'conversation:send',
+  'search:provide',
+]);
+
 // Manifest hygiene gates (hard failures) and soft warnings. Keep these aligned with PLUGIN-STANDARD.md.
 function validateManifest(id, manifest) {
   if (manifest.sessionScoped === undefined) {
@@ -31,6 +48,14 @@ function validateManifest(id, manifest) {
   }
   if (manifest.status === 'stable' && !manifest.testedOpenWAVersion) {
     throw new Error(`${id}: status "stable" requires testedOpenWAVersion (the newest host actually smoke-tested)`);
+  }
+  for (const p of manifest.permissions ?? []) {
+    if (!HOST_PERMISSIONS.has(p)) {
+      throw new Error(
+        `${id}: unknown permission "${p}" — the host enforces only ${[...HOST_PERMISSIONS].join(', ')}. ` +
+          `If OpenWA has added one, add it to HOST_PERMISSIONS in this file in the same change.`,
+      );
+    }
   }
   if (!manifest.i18n || Object.keys(manifest.i18n).length === 0) {
     console.warn(`⚠ ${id}: no i18n block — dashboard shows English only`);


### PR DESCRIPTION
## What

Three gates that could let something wrong through, and three documents describing a gateway this repo no longer targets. Tooling and documentation only — nothing here ships in a `.zip` or in `plugins.json`, so **no plugin needs a release**.

## The three gates

### 1. `catalog.mjs` never checked that a permission exists

The declared array went straight into `plugins.json` — the data source the in-dashboard marketplace reads — so an invented or misspelled name was published verbatim, and would only surface when the capability it was meant to unlock silently failed at runtime.

This is the hole that let `storage:use` reach seven manifests without anything in this repo ever looking at the name. It happened to be correct. A closed list makes adopting a real new permission a deliberate edit in one place instead of a silent publish.

```
before:  "totally-made-up" → catalog:check exit 0, published to plugins.json
after:   faq-bot: unknown permission "totally-made-up" — the host enforces only …
```

### 2. `npm run build` exited 0 when a plugin failed

A bare shell loop with no `set -e` reports only the last plugin's status, so a failure in any of the first nine printed and was thrown away. CI was never exposed — its own `run:` block aborts, and `release.yml` packages a single plugin — but a green local build was not evidence that all ten built.

```
before:  first plugin fails → exit 0, loop continues
after:   first plugin fails → exit 1, stops
```

### 3. `package.mjs` never compared the archive to `manifest.main`

It chooses the members itself and only checked that `main` is *present as a field*. A manifest pointing anywhere else produced a package every gate here accepts and the host rejects at install — after the release is tagged and published.

```
before:  main "build/bundle.js" → packaged fine, catalog green, tests green
after:   ✗ faq-bot: manifest main "build/bundle.js" is not in the package (members: …)
```

## The three documents

| Where | Was | Now |
| --- | --- | --- |
| `README.md` management endpoints | 8 rows without the global `/api` prefix — every path as written 404s | prefixed, with a line saying why |
| `README.md` hook events | missing `message:persisted`, `message:deleted`, `ingress:error` | complete, matching `types/openwa.d.ts` |
| `PLUGIN-STANDARD.md` permissions | "the five values the host enforces" | seven, with `storage:use` and `search:provide` described |
| `PLUGIN-STANDARD.md` catalog shape | `ingress: [{ route, methods, signature }]`; no `i18n` | `{ route, signature }` (what the generator emits, pinned by a test); `i18n` documented |
| `PLUGIN-STANDARD.md` header | "Verified against … v0.7.x" while the body documents 0.12+ behaviour | pinned to the same baseline as `types/openwa.d.ts`, with the moving parts named |
| `gsheets-logger/README.md` | advertised 0.2.3 as current against a 0.3.3 manifest, in four places | version examples written so they cannot go stale again; the duplicated "Latest:" line removed |

While fixing the endpoint table I swept the same defect everywhere rather than half of it: three more bare gateway paths in `gsheets-logger`'s README, and the `healthCheck()` row in the lifecycle table. Eleven lines, all of them.

## Verification

Each gate driven red before being trusted, and each checked in both directions — the honest input must still pass, or a gate just gets disabled:

```
✅ invented permission → catalog:check RED       ✅ the seven real ones still pass
✅ first plugin fails → npm run build RED        ✅ and it stops rather than continuing
✅ main not in the package → package.mjs RED     ✅ the honest manifest still packages
```

```
tsc --noEmit             0 errors
npm test                 553/553 pass, 0 fail
npm run catalog:check    up to date (10 plugins)
npm run build            10/10 packaged

regression — all four earlier proof suites re-run unchanged:
  permission gate · floor+/api gaps · precondition · vacuous-pass      0 wrong
```