### PR TITLE
fix: close gaps in the packaging, release, and runtime guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
               echo "::endgroup::"
             fi
           done
+
+      - name: Every built bundle loads as a plugin
+        run: node scripts/loader-check.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,22 @@ jobs:
             echo "tag version $PLUGIN_VERSION != manifest version $MV"; exit 1
           fi
 
+      # ci.yml runs on pushes and PRs to main, never on tags — and a tag can be pushed at any commit.
+      # Without this the release path would happily publish an artifact built from a red commit, and the
+      # zip reaches users the moment the Release is created.
+      - name: Verify before publishing anything
+        run: |
+          npm run typecheck
+          npm test
+          npm run catalog:check
+
       - name: Build & package (validates version↔changelog and size)
         run: node package.mjs "$PLUGIN_ID"
+
+      # The last point at which a bundle the host cannot load is still cheap to fix. After this step the
+      # Release is created and the zip is installable.
+      - name: The built bundle loads as a plugin
+        run: node scripts/loader-check.mjs "$PLUGIN_ID"
 
       - name: Checksum + release notes
         run: |

--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ## [Unreleased]
 
+### Fixed
+
+- **Attachment uploads now use an unpredictable multipart boundary.** The boundary was built from the
+  conversation id and the file's byte length, both of which a sender can work out from the media they
+  send — so an attachment crafted to contain that exact boundary could close the part early and append
+  parts of its own to the request reaching Chatwoot. The boundary is now 16 random bytes, which removes
+  the possibility rather than filtering for it.
+
 ## [0.9.1] — 2026-08-12
 
 ### Changed

--- a/chatwoot-adapter/chatwoot-client.test.ts
+++ b/chatwoot-adapter/chatwoot-client.test.ts
@@ -145,6 +145,26 @@ test('postMedia marks a voice note and threads it (is_voice_message + source_id 
   assert.match(raw, /filename="voice.ogg"/);
 });
 
+test('postMedia picks an unpredictable boundary instead of deriving it from the attachment', async () => {
+  // The boundary was `----cw<conversationId><data.byteLength>` — both halves derivable from an attachment
+  // the sender controls, so crafted bytes carrying that exact boundary would forge extra multipart parts.
+  const { fn, calls } = fakeFetch({ 'POST /api/v1/accounts/3/conversations/55/messages': { body: { id: 1 } } });
+  const c = new ChatwootClient(fn, cfg);
+  const file = { filename: 'a.jpg', contentType: 'image/jpeg', data: new Uint8Array([1, 2, 3]) };
+  const boundaryOf = () => /boundary=(.+)$/.exec(calls.at(-1)!.init!.headers!['Content-Type'])![1];
+
+  await c.postMedia(55, '', file);
+  const first = boundaryOf();
+  await c.postMedia(55, '', file);
+  const second = boundaryOf();
+
+  assert.notEqual(first, second, 'two identical posts must not reuse a boundary');
+  assert.doesNotMatch(first, /^----cw\d+$/, 'boundary must not be conversation id + byte length');
+  // The header and the body must agree, or Chatwoot cannot parse the parts at all.
+  const raw = Buffer.from(calls.at(-1)!.init!.body as Uint8Array).toString('latin1');
+  assert.ok(raw.startsWith(`--${second}\r\n`), 'body must open with the boundary the header announces');
+});
+
 test('postMedia on a non-ok response rejects with err.status set (so the 404 mapping-rebuild path can branch on it)', async () => {
   // Inbound/sent recovery branches on `err.status === 404` to rebuild the dangling conversation mapping.
   // json() already attaches status; postMedia did NOT — a media 404 would silently dead-letter. This test

--- a/chatwoot-adapter/chatwoot-client.ts
+++ b/chatwoot-adapter/chatwoot-client.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { buildMultipartBody } from './multipart.ts';
 
 export interface ChatwootConfig {
@@ -165,7 +166,9 @@ export class ChatwootClient {
     file: { filename: string; contentType: string; data: Uint8Array },
     opts: MessagePostOptions & { isVoiceMessage?: boolean } = {},
   ): Promise<{ id: number }> {
-    const boundary = `----cw${conversationId}${file.data.byteLength}`;
+    // Random, not derived: the media bytes are attacker-controlled, and a boundary they can predict is a
+    // boundary they can embed to forge extra parts. Matches typebot-connector's producer.
+    const boundary = `----cw${randomBytes(16).toString('hex')}`;
     const fields = [
       { name: 'content', value: content },
       { name: 'message_type', value: opts.messageType ?? 'incoming' },

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this plugin adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The version here always matches `manifest.json`'s `version`.
 
+## [Unreleased]
+
+### Fixed
+
+- **The buffer is now bounded by size, not only by row count.** The 5,000-row cap allowed cells of up
+  to 50,000 characters across 14 columns, so the row count alone permitted a buffer far larger than the
+  worker heap — reachable whenever Sheets is unreachable and the retain-on-failure path holds rows.
+  A total-character cap now applies alongside it, dropping oldest first.
+- **A restored buffer is filtered and capped as it loads, and says what it dropped.** Rows that are not
+  rows of strings are discarded rather than carried into the size accounting and the Sheets append, and
+  a buffer persisted before this cap existed no longer stays oversized until the next message arrives.
+- **A rejected `storage.set` on disable no longer escapes the lifecycle call.** Storage rejects at the
+  quota; the number of rows that failed to persist is now reported instead of lost without a trace.
+
 ## [0.3.3] — 2026-08-12
 
 ### Changed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -34,7 +34,8 @@ The installed version is also visible in the OpenWA dashboard Plugins list, via
 - **Logs all four message events** — `message:received`, `message:sent`, `message:failed`, `message:ack` —
   one row per event with a fixed 14-column schema.
 - **Buffered batch writes** with retain-on-failure (rows are kept and retried on a Sheets error),
-  a 5000-row cap, and persistence to plugin storage so the buffer survives restarts.
+  a 5000-row and ~4M-character cap (oldest dropped first, reported in the log), and persistence to
+  plugin storage so the buffer survives restarts.
 - **Service-account auth** (JWT RS256) using only Node built-ins (`crypto` + `fetch`) — **zero runtime
   dependencies**, so the package is tiny.
 - **Formula-injection safe** — writes with `valueInputOption=RAW` and neutralizes CSV/Sheets formula

--- a/gsheets-logger/index.test.ts
+++ b/gsheets-logger/index.test.ts
@@ -189,3 +189,47 @@ test('onDisable survives a storage quota rejection and says how many rows were l
     `expected the number of lost rows to be logged, got ${JSON.stringify(logged)}`,
   );
 });
+
+const enableCtx = (stored: unknown, warns: string[] = []): unknown => ({
+  config: { spreadsheetId: 'sid', serviceAccountJson: validSa },
+  net: { fetch: async () => ({ ok: true, status: 200, body: '{}' }) },
+  storage: { get: async () => stored, set: async () => {} },
+  logger: { log: (): void => {}, warn: (m: string): void => void warns.push(m), error: (): void => {} },
+  registerHook: (): void => {},
+});
+
+test('a restored buffer is filtered to rows of strings before anything uses it', async () => {
+  // The buffer comes back from ctx.storage, and everything downstream assumes rows of strings — the
+  // size accounting reads every cell's length, and the Sheets append sends them verbatim. A stored
+  // value of another shape must not reach either.
+  const logger = new GSheetsLogger();
+  await logger.onEnable(enableCtx([['ok', 'row'], null, 42, [{}], ['also', 'fine']]) as never);
+  await logger.onUnload();
+  assert.deepEqual((logger as unknown as { buffer: string[][] }).buffer, [['ok', 'row'], ['also', 'fine']]);
+});
+
+test('a restored buffer is capped on load, not only when the next message arrives', async () => {
+  // Without this the plugin can come back up holding far more than the cap allows and stay that way
+  // until traffic resumes — exactly when the host is least able to absorb it.
+  const stored = Array.from({ length: 500 }, () => ['x'.repeat(50_000)]);
+  const logger = new GSheetsLogger();
+  await logger.onEnable(enableCtx(stored) as never);
+  await logger.onUnload();
+  const buffer = (logger as unknown as { buffer: string[][] }).buffer;
+  const chars = buffer.reduce((n, row) => n + row.reduce((m, cell) => m + cell.length, 0), 0);
+  assert.ok(chars <= 8_000_000, `restored buffer holds ${chars} characters`);
+});
+
+test('restoring a buffer reports what it dropped instead of losing rows silently', async () => {
+  // This plugin exists to produce a complete audit trail, so discarding rows without a word is the
+  // worst shape the loss can take — the operator has no way to know the sheet has a hole in it.
+  const warns: string[] = [];
+  const stored = [...Array.from({ length: 400 }, () => ['x'.repeat(50_000)]), 'garbage', null];
+  const logger = new GSheetsLogger();
+  await logger.onEnable(enableCtx(stored, warns) as never);
+  await logger.onUnload();
+
+  assert.equal(warns.length, 1, `expected exactly one warning, got ${JSON.stringify(warns)}`);
+  assert.match(warns[0], /2 malformed/);
+  assert.match(warns[0], /\d+ oldest/);
+});

--- a/gsheets-logger/index.test.ts
+++ b/gsheets-logger/index.test.ts
@@ -138,3 +138,54 @@ test('logs at observer priority so a responder claim can never starve it', async
   assert.equal(registered.length, 4);
   assert.ok(registered.every(r => r.priority === 10), 'every logged event registers at 10');
 });
+
+test('the buffer is capped by total size, not just row count', () => {
+  // MAX_BUFFER caps the row COUNT at 5,000 while row.ts allows 50,000 characters per cell, so the row
+  // cap alone permits a buffer far past the 256 MB worker heap — and the message body a sender controls
+  // is one of those cells. Rows are only retained this long when Sheets is unreachable.
+  const logger = new GSheetsLogger();
+  const harness = logger as unknown as {
+    buffer: string[][];
+    ctx: unknown;
+    batchSize: number;
+    enqueue(hook: unknown): void;
+  };
+  harness.ctx = { logger: { warn: (): void => {} } };
+  harness.batchSize = Number.MAX_SAFE_INTEGER; // never trip the size-triggered flush
+  const big = 'x'.repeat(50_000);
+
+  for (let i = 0; i < 500; i++) {
+    harness.enqueue({
+      event: 'message:received',
+      sessionId: 's1',
+      timestamp: new Date('2026-06-22T10:00:00.000Z'),
+      source: 'Engine',
+      data: { id: `M${i}`, from: 'a@c.us', to: 'me', chatId: 'a@c.us', body: big, type: 'text', fromMe: false, isGroup: false },
+    });
+  }
+
+  const chars = harness.buffer.reduce((n, row) => n + row.reduce((m, cell) => m + cell.length, 0), 0);
+  assert.ok(harness.buffer.length < 500, `expected oldest rows to be dropped, buffer still holds ${harness.buffer.length}`);
+  assert.ok(chars <= 8_000_000, `buffer holds ${chars} characters — the row cap alone does not bound memory`);
+});
+
+test('onDisable survives a storage quota rejection and says how many rows were lost', async () => {
+  // ctx.storage.set REJECTS once the plugin directory would exceed its 50 MiB quota, and the repo
+  // standard is explicit that a swallowed quota error is silent data loss. onDisable persisted without
+  // a guard, so the rejection escaped the lifecycle call itself.
+  const logger = new GSheetsLogger();
+  const logged: string[] = [];
+  const harness = logger as unknown as { client: unknown; ctx: unknown; buffer: string[][] };
+  harness.client = null; // flush() is a no-op, so onDisable goes straight to persisting
+  harness.ctx = {
+    storage: { set: async (): Promise<void> => { throw new Error('quota exceeded'); } },
+    logger: { error: (msg: string): void => void logged.push(msg), warn: (): void => {} },
+  };
+  harness.buffer = [['a'], ['b']];
+
+  await assert.doesNotReject(() => logger.onDisable());
+  assert.ok(
+    logged.some((m) => m.includes('2')),
+    `expected the number of lost rows to be logged, got ${JSON.stringify(logged)}`,
+  );
+});

--- a/gsheets-logger/index.ts
+++ b/gsheets-logger/index.ts
@@ -108,8 +108,22 @@ export default class GSheetsLogger implements IPlugin {
     this.client = new SheetsClient(ctx.net.fetch.bind(ctx.net), sa, config.spreadsheetId, config.sheetTab);
     this.batchSize = config.flushBatchSize;
 
+    // The only place untrusted data enters the buffer. Everything downstream assumes rows of strings —
+    // the size accounting reads each cell's length, and appendRows sends them verbatim — so filter here
+    // rather than defending in both. Cap on load too: a buffer persisted before the cap existed, or by
+    // an older version, would otherwise stay oversized until the next message arrived.
     const restored = await ctx.storage.get<string[][]>(BUFFER_KEY);
-    if (Array.isArray(restored)) this.buffer = restored;
+    if (Array.isArray(restored)) {
+      this.buffer = restored.filter((row) => Array.isArray(row) && row.every((cell) => typeof cell === 'string'));
+      const malformed = restored.length - this.buffer.length;
+      const capped = capBuffer(this.buffer, MAX_BUFFER, MAX_BUFFER_CHARS);
+      // Once, on enable, and only when something was actually lost. This plugin exists to produce a
+      // complete audit trail, so a hole in the sheet the operator never hears about is the worst
+      // shape the loss can take.
+      if (malformed > 0 || capped > 0) {
+        ctx.logger.warn(`gsheets-logger: restored buffer dropped ${malformed} malformed and ${capped} oldest rows`);
+      }
+    }
 
     for (const event of LOGGED_EVENTS) {
       ctx.registerHook(

--- a/gsheets-logger/index.ts
+++ b/gsheets-logger/index.ts
@@ -5,6 +5,10 @@ import { buildRow } from './row.ts';
 const LOGGED_EVENTS: HookEvent[] = ['message:received', 'message:sent', 'message:failed', 'message:ack'];
 const BUFFER_KEY = 'buffer';
 const MAX_BUFFER = 5000;
+// The row cap alone does not bound memory: row.ts allows 50,000 characters per cell across 14 columns,
+// so 5,000 rows can reach hundreds of millions of characters against a 256 MB worker heap — and the
+// message body a sender controls is one of those cells. ~4M characters is ~8 MB of UTF-16.
+const MAX_BUFFER_CHARS = 4_000_000;
 
 // Observer band. Must run before any responder: a responder returning {continue:false} ends the chain,
 // and at the default priority of 100 this plugin would simply stop seeing claimed messages.
@@ -70,6 +74,24 @@ export async function flushBuffer(buffer: string[][], append: (rows: string[][])
   }
 }
 
+// Drop oldest-first until both caps hold, returning how many rows went. Rows only pile up this deep
+// while Sheets is unreachable, and the oldest are the least useful. The character total is recomputed
+// per call rather than tracked incrementally because flushBuffer splices and unshifts this same array
+// from outside — a running total would drift out of sync with it on every retained failure.
+export function capBuffer(buffer: string[][], maxRows: number, maxChars: number): number {
+  const before = buffer.length;
+  if (buffer.length > maxRows) buffer.splice(0, buffer.length - maxRows);
+
+  let total = 0;
+  for (const row of buffer) for (const cell of row) total += cell.length;
+  // Keep the newest row whatever its size: a single row over the cap is still worth more than nothing.
+  while (total > maxChars && buffer.length > 1) {
+    for (const cell of buffer[0]) total -= cell.length;
+    buffer.shift();
+  }
+  return before - buffer.length;
+}
+
 export default class GSheetsLogger implements IPlugin {
   private buffer: string[][] = [];
   private client: SheetsClient | null = null;
@@ -117,7 +139,13 @@ export default class GSheetsLogger implements IPlugin {
   async onDisable(): Promise<void> {
     this.stopTimer();
     await this.flush();
-    await this.ctx?.storage.set(BUFFER_KEY, this.buffer);
+    try {
+      await this.ctx?.storage.set(BUFFER_KEY, this.buffer);
+    } catch (err) {
+      // `set` rejects once the plugin directory would exceed its 50 MiB quota. Nothing here can rescue
+      // the rows, but an unhandled rejection would both lose them silently and escape onDisable itself.
+      this.ctx?.logger.error(`gsheets-logger: could not persist ${this.buffer.length} buffered rows`, err);
+    }
   }
 
   async onUnload(): Promise<void> {
@@ -143,10 +171,9 @@ export default class GSheetsLogger implements IPlugin {
 
   private enqueue(hook: HookContext): void {
     this.buffer.push(buildRow(hook));
-    if (this.buffer.length > MAX_BUFFER) {
-      const dropped = this.buffer.length - MAX_BUFFER;
-      this.buffer.splice(0, dropped);
-      this.ctx?.logger.warn(`gsheets-logger: buffer cap ${MAX_BUFFER} exceeded, dropped ${dropped} oldest rows`);
+    const dropped = capBuffer(this.buffer, MAX_BUFFER, MAX_BUFFER_CHARS);
+    if (dropped > 0) {
+      this.ctx?.logger.warn(`gsheets-logger: buffer cap exceeded, dropped ${dropped} oldest rows`);
     }
     if (this.buffer.length >= this.batchSize) void this.flush();
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "set -e; for d in */; do if [ -f \"${d}manifest.json\" ]; then node package.mjs \"${d%/}\"; fi; done",
     "catalog": "node scripts/catalog.mjs",
     "catalog:check": "node scripts/catalog.mjs --check",
+    "loader:check": "node scripts/loader-check.mjs",
     "test": "node scripts/run-tests.mjs",
     "test:coverage": "node scripts/run-tests.mjs --experimental-test-coverage",
     "typecheck": "tsc --noEmit"

--- a/package.mjs
+++ b/package.mjs
@@ -4,6 +4,7 @@ import { rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { zipStore } from './scripts/zip-store.mjs';
+import { configUiMember } from './scripts/entry-path.mjs';
 
 const plugin = process.argv[2];
 if (!plugin) {
@@ -65,8 +66,14 @@ const entries = ['manifest.json', 'dist/index.js', 'dist/package.json'];
 // A configUi plugin ships a static editor bundle the host serves in a sandboxed iframe — include it.
 if (manifest.configUi?.entry) {
   const ui = manifest.configUi.entry;
+  let member;
+  try {
+    member = configUiMember(ui);
+  } catch (e) {
+    fail(e.message);
+  }
   if (!existsSync(join(dir, ui))) fail(`configUi.entry "${ui}" not found`);
-  entries.push(ui.includes('/') ? ui.split('/')[0] : ui);
+  entries.push(member);
 }
 
 // Resolve each entry (file or directory) to zip members with forward-slash relative paths.
@@ -87,12 +94,14 @@ if (!result.some((f) => f.name === mainInZip)) {
   fail(`manifest main "${manifest.main}" is not in the package (members: ${result.map((f) => f.name).join(', ')})`);
 }
 
-await writeFile(zipPath, zipStore(result));
-
 // ── Report size + sha256 (release artifacts — surfaced here and in the GitHub Release) ──
-const buf = readFileSync(zipPath);
-const sha256 = createHash('sha256').update(buf).digest('hex');
-const kb = (buf.length / 1024).toFixed(1);
-if (buf.length > 5 * 1024 * 1024) fail(`package is ${kb} KB, over the 5 MB install limit`);
+// Size is checked before the write, not after: an oversized archive that fails the limit used to be
+// left behind on disk anyway.
+const zip = zipStore(result);
+const kb = (zip.length / 1024).toFixed(1);
+if (zip.length > 5 * 1024 * 1024) fail(`package is ${kb} KB, over the 5 MB install limit`);
+await writeFile(zipPath, zip);
+
+const sha256 = createHash('sha256').update(zip).digest('hex');
 console.log(`✓ Packaged ${plugin} v${manifest.version} → ${zipName}  (${kb} KB)`);
 console.log(`  sha256: ${sha256}`);

--- a/scripts/catalog.test.mjs
+++ b/scripts/catalog.test.mjs
@@ -5,6 +5,41 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 
+// Three of the checks below iterate a list that can come back empty — no plugin directories, no stable
+// entries, no catalog entries at all — and an empty loop is indistinguishable from a passing one. Proven
+// rather than assumed: run this file against a tree holding `{"plugins":[]}` and no plugin directories,
+// and three of the five tests stay green having examined nothing. Only the two that already assert a
+// non-empty list go red.
+//
+// Asserting the inputs once here is better than counting units inside each check: while this passes,
+// none of those empty-iteration paths can fire, and when an input disappears THIS test names which one.
+// Discovery is the widest version of the problem — `root` is derived from this file's own location, so
+// moving the file empties every list below at once.
+test('the catalog supplies what the checks below need', () => {
+  const root = new URL('../', import.meta.url);
+  const dirs = readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(new URL(`${d.name}/manifest.json`, root)))
+    .map((d) => d.name);
+  const catalog = JSON.parse(readFileSync(new URL('plugins.json', root), 'utf8'));
+  const entries = catalog.plugins ?? catalog;
+
+  assert.ok(dirs.length > 0, `no plugin directories discovered under ${root.pathname}`);
+  assert.ok(entries.length > 0, 'plugins.json lists no entries — the drift checks would compare nothing');
+  assert.ok(
+    entries.some((e) => e.status === 'stable'),
+    'no entry is stable — the full-i18n check would iterate an empty list',
+  );
+  // The config-translation check skips a plugin with no config fields or no i18n. That skip is correct
+  // per plugin and fatal across all of them, so assert at least one plugin actually reaches the loop.
+  assert.ok(
+    dirs.some((d) => {
+      const m = JSON.parse(readFileSync(new URL(`${d}/manifest.json`, root), 'utf8'));
+      return Object.keys(m.configSchema?.properties ?? {}).length > 0 && m.i18n;
+    }),
+    'no plugin has both configSchema fields and an i18n block — the config-translation check would examine nothing',
+  );
+});
+
 test('plugins.json carries i18n for a plugin whose manifest has it', () => {
   const catalog = JSON.parse(readFileSync(new URL('../plugins.json', import.meta.url), 'utf8'));
   const entries = catalog.plugins ?? catalog;

--- a/scripts/catalog.test.mjs
+++ b/scripts/catalog.test.mjs
@@ -30,13 +30,15 @@ test('the catalog supplies what the checks below need', () => {
     'no entry is stable — the full-i18n check would iterate an empty list',
   );
   // The config-translation check skips a plugin with no config fields or no i18n. That skip is correct
-  // per plugin and fatal across all of them, so assert at least one plugin actually reaches the loop.
+  // per plugin and fatal across all of them, so assert at least one plugin actually reaches the loop —
+  // and reaches its INNER loop too: that one iterates the locales, so a manifest carrying `"i18n": {}`
+  // satisfies a truthy check while the check itself still examines zero locales.
   assert.ok(
     dirs.some((d) => {
       const m = JSON.parse(readFileSync(new URL(`${d}/manifest.json`, root), 'utf8'));
-      return Object.keys(m.configSchema?.properties ?? {}).length > 0 && m.i18n;
+      return Object.keys(m.configSchema?.properties ?? {}).length > 0 && Object.keys(m.i18n ?? {}).length > 0;
     }),
-    'no plugin has both configSchema fields and an i18n block — the config-translation check would examine nothing',
+    'no plugin has both configSchema fields and a non-empty i18n block — the config-translation check would examine nothing',
   );
 });
 

--- a/scripts/entry-path.mjs
+++ b/scripts/entry-path.mjs
@@ -1,14 +1,26 @@
-import { isAbsolute } from 'node:path';
+import { isAbsolute, posix } from 'node:path';
 
 // `configUi.entry` comes from a manifest, and the packager archives whatever it names — a directory
-// entry pulls in everything beneath it, recursively. An entry that climbs out of the plugin directory
-// therefore archives the repo itself (node_modules included), and the size limit that would catch it
-// only runs after the zip is already on disk. Refuse anything but a plain relative path, and return
-// the top-level name to add to the archive.
+// entry pulls in everything beneath it, recursively. Two things therefore have to hold: the entry must
+// stay inside the plugin directory, and the top-level name handed to the packager must come from the
+// NORMALISED path. Spelling it './config/index.html' is perfectly valid and names a real file, but its
+// literal first segment is '.', which would archive the entire plugin directory.
+//
+// Normalise first, judge second: a build should not break over punctuation, and the two ways an entry
+// can be wrong — escaping the directory, or naming the directory itself — get different messages,
+// because they need different fixes.
 export function configUiMember(entry) {
-  const segments = entry.split('/');
-  if (isAbsolute(entry) || segments.includes('..') || segments.includes('')) {
-    throw new Error(`configUi.entry "${entry}" must be a relative path inside the plugin directory`);
+  const rel = posix.normalize(String(entry).split('\\').join('/'));
+  const segments = rel.split('/').filter((s) => s !== '');
+
+  // Backslashes are folded above so a Windows-style '..\secrets' cannot pass as a single segment on a
+  // POSIX runner; testing the folded path for absoluteness also catches a UNC '\\server\share', which
+  // POSIX isAbsolute() reads as relative.
+  if (isAbsolute(entry) || posix.isAbsolute(rel) || segments[0] === '..') {
+    throw new Error(`configUi.entry "${entry}" must stay inside the plugin directory`);
+  }
+  if (segments.length === 0 || segments[0] === '.') {
+    throw new Error(`configUi.entry "${entry}" names the plugin directory itself — point it at the entry file`);
   }
   return segments[0];
 }

--- a/scripts/entry-path.mjs
+++ b/scripts/entry-path.mjs
@@ -1,0 +1,14 @@
+import { isAbsolute } from 'node:path';
+
+// `configUi.entry` comes from a manifest, and the packager archives whatever it names — a directory
+// entry pulls in everything beneath it, recursively. An entry that climbs out of the plugin directory
+// therefore archives the repo itself (node_modules included), and the size limit that would catch it
+// only runs after the zip is already on disk. Refuse anything but a plain relative path, and return
+// the top-level name to add to the archive.
+export function configUiMember(entry) {
+  const segments = entry.split('/');
+  if (isAbsolute(entry) || segments.includes('..') || segments.includes('')) {
+    throw new Error(`configUi.entry "${entry}" must be a relative path inside the plugin directory`);
+  }
+  return segments[0];
+}

--- a/scripts/entry-path.test.mjs
+++ b/scripts/entry-path.test.mjs
@@ -6,12 +6,34 @@ test('a configUi entry resolves to the top-level name the packager archives', ()
   assert.equal(configUiMember('editor.html'), 'editor.html');
   assert.equal(configUiMember('config/index.html'), 'config');
   assert.equal(configUiMember('config/assets/app.js'), 'config');
+  assert.equal(configUiMember('.hidden'), '.hidden');
+});
+
+test('a configUi entry is normalised before it is judged, not rejected for spelling', () => {
+  // These all name a real file inside the plugin, so refusing them would break a build over punctuation.
+  // The packager archives the top-level name, which must come from the NORMALISED path: './config/x'
+  // spelled literally would hand it '.', i.e. the whole plugin directory.
+  assert.equal(configUiMember('./config/index.html'), 'config');
+  assert.equal(configUiMember('config/'), 'config');
+  assert.equal(configUiMember('config/./index.html'), 'config');
+  assert.equal(configUiMember('config//assets/app.js'), 'config');
+  assert.equal(configUiMember('config/sub/../index.html'), 'config');
 });
 
 test('a configUi entry that climbs out of the plugin directory is refused', () => {
   // The packager expands a directory entry recursively, so `..` reaches the repo root: an entry of
   // '../types/openwa.d.ts' archives every sibling plugin and all of node_modules.
-  for (const escape of ['../types/openwa.d.ts', '..', 'config/../../secrets', '/etc/passwd', '/', '']) {
-    assert.throws(() => configUiMember(escape), /inside the plugin directory/, `expected "${escape}" to be refused`);
+  for (const escape of ['../types/openwa.d.ts', '..', 'config/../../secrets', '/etc/passwd', '/', '..\\secrets', '\\\\server\\share']) {
+    assert.throws(() => configUiMember(escape), /must stay inside the plugin directory/, `expected "${escape}" to be refused`);
+  }
+});
+
+test('a configUi entry naming the plugin directory itself is refused, and says so', () => {
+  // The packager collects a directory entry recursively, so an entry that reduces to the plugin root
+  // archives every source file, test and stray note in it. Verified before this guard existed: such an
+  // entry produced a 10-member archive where 4 were expected. The message must not claim the path
+  // escaped the directory — it did not, it named the directory.
+  for (const root of ['.', './', 'config/..', '']) {
+    assert.throws(() => configUiMember(root), /names the plugin directory itself/, `expected "${root}" to be refused`);
   }
 });

--- a/scripts/entry-path.test.mjs
+++ b/scripts/entry-path.test.mjs
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { configUiMember } from './entry-path.mjs';
+
+test('a configUi entry resolves to the top-level name the packager archives', () => {
+  assert.equal(configUiMember('editor.html'), 'editor.html');
+  assert.equal(configUiMember('config/index.html'), 'config');
+  assert.equal(configUiMember('config/assets/app.js'), 'config');
+});
+
+test('a configUi entry that climbs out of the plugin directory is refused', () => {
+  // The packager expands a directory entry recursively, so `..` reaches the repo root: an entry of
+  // '../types/openwa.d.ts' archives every sibling plugin and all of node_modules.
+  for (const escape of ['../types/openwa.d.ts', '..', 'config/../../secrets', '/etc/passwd', '/', '']) {
+    assert.throws(() => configUiMember(escape), /inside the plugin directory/, `expected "${escape}" to be refused`);
+  }
+});

--- a/scripts/loader-check.mjs
+++ b/scripts/loader-check.mjs
@@ -1,0 +1,77 @@
+// Loader contract for built bundles. Nothing else in this repo loads one: package.mjs asserts that
+// `main` is a MEMBER of the archive, not that the file can be required or that it exports what the host
+// needs. So a bundle that throws on require — or default-exports the wrong shape — is first discovered
+// by the host at install, after the tag and the GitHub Release are already published. Run after a build.
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { discoverPluginDirs } from './run-tests.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export function assertLoadable(mod, id) {
+  const Plugin = mod?.default;
+  if (typeof Plugin !== 'function') {
+    throw new Error(`${id}: dist/index.js does not default-export a constructor (got ${typeof Plugin})`);
+  }
+  let instance;
+  try {
+    instance = new Plugin();
+  } catch (err) {
+    throw new Error(`${id}: the default export threw on construction — ${err.message}`);
+  }
+  // onEnable is the one method every plugin in the catalog implements and the host always calls.
+  if (typeof instance.onEnable !== 'function') {
+    throw new Error(`${id}: the default export has no onEnable() — the host cannot run it as a plugin`);
+  }
+}
+
+// Only run when invoked directly (assertLoadable is imported by scripts/loader-check.test.mjs).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const require = createRequire(import.meta.url);
+  const all = discoverPluginDirs(ROOT);
+  // Discovery returning nothing would otherwise report success having loaded not one bundle.
+  if (all.length === 0) {
+    console.error('✗ no plugin directories discovered — nothing was checked');
+    process.exit(1);
+  }
+
+  // Optional plugin id: the release workflow builds one plugin, so checking all ten would only report
+  // nine missing bundles. Filtered from discovery rather than trusted, so a typo fails loudly.
+  const requested = process.argv[2];
+  const dirs = requested ? all.filter((d) => d === requested) : all;
+  if (requested && dirs.length === 0) {
+    console.error(`✗ no plugin directory named "${requested}"`);
+    process.exit(1);
+  }
+
+  const failures = [];
+  for (const id of dirs) {
+    const bundle = join(ROOT, id, 'dist', 'index.js');
+    if (!existsSync(bundle)) {
+      failures.push(`${id}: dist/index.js is missing — run \`npm run build\` first`);
+      continue;
+    }
+    // require() is separated from the shape check so a bundle that throws on load is still reported
+    // against the plugin it belongs to — a bare "missing dependency" names nothing across ten plugins.
+    let mod;
+    try {
+      mod = require(bundle);
+    } catch (err) {
+      failures.push(`${id}: dist/index.js threw on require — ${err.message}`);
+      continue;
+    }
+    try {
+      assertLoadable(mod, id);
+    } catch (err) {
+      failures.push(err.message);
+    }
+  }
+
+  if (failures.length) {
+    for (const f of failures) console.error(`✗ ${f}`);
+    process.exit(1);
+  }
+  console.log(`Loader contract OK (${dirs.length} plugin(s)).`);
+}

--- a/scripts/loader-check.mjs
+++ b/scripts/loader-check.mjs
@@ -47,6 +47,7 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
   }
 
   const failures = [];
+  let handles = process.getActiveResourcesInfo().length;
   for (const id of dirs) {
     const bundle = join(ROOT, id, 'dist', 'index.js');
     if (!existsSync(bundle)) {
@@ -67,6 +68,16 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     } catch (err) {
       failures.push(err.message);
     }
+
+    // A bundle that opens a timer or socket while loading keeps this process alive after the last
+    // check, which in CI is a job hanging until the six-hour timeout with "OK" already in the log —
+    // the worst failure mode a gate can have. It is also a contract violation worth naming: a plugin
+    // starts its timers in onEnable, not at construction.
+    const now = process.getActiveResourcesInfo().length;
+    if (now > handles) {
+      failures.push(`${id}: loading left ${now - handles} handle(s) open — start timers and sockets in onEnable, not at load`);
+    }
+    handles = now;
   }
 
   if (failures.length) {
@@ -74,4 +85,6 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     process.exit(1);
   }
   console.log(`Loader contract OK (${dirs.length} plugin(s)).`);
+  // Explicit: a bundle that slipped a handle past the check above would otherwise hold the event loop.
+  process.exit(0);
 }

--- a/scripts/loader-check.test.mjs
+++ b/scripts/loader-check.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { assertLoadable } from './loader-check.mjs';
+
+test('a bundle that default-exports a usable plugin class passes', () => {
+  class Good {
+    async onEnable() {}
+  }
+  assert.doesNotThrow(() => assertLoadable({ default: Good }, 'good-plugin'));
+});
+
+test('a bundle the host could not instantiate is refused, and the message names the plugin', () => {
+  // Each of these produces an archive package.mjs accepts — `main` is present as a member — and that the
+  // host then rejects at install, after the tag and the GitHub Release are already published.
+  const broken = [
+    [{}, 'no default export at all'],
+    [{ default: {} }, 'default export is not constructible'],
+    [{ default: 42 }, 'default export is a primitive'],
+    [{ default: class NoHooks {} }, 'instance has no onEnable()'],
+    [
+      {
+        default: class Throws {
+          constructor() {
+            throw new Error('missing dependency');
+          }
+        },
+      },
+      'constructor throws',
+    ],
+  ];
+
+  for (const [mod, why] of broken) {
+    assert.throws(() => assertLoadable(mod, 'bad-plugin'), /bad-plugin/, `expected a refusal naming the plugin: ${why}`);
+  }
+});

--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -121,6 +121,44 @@ test('every gateway URL in a README carries the /api prefix', () => {
   assert.deepEqual(offenders, []);
 });
 
+// The commands a README shows that PUT a plugin's config.
+//
+// Two parsing traps this went through, both of which left the check green while reading less than it
+// appeared to. Joining backslash continuations first is required: matching a command and its
+// continuations in one pattern does not work, because the leading `[^\n]*` eats the trailing backslash
+// and the continuation group may repeat zero times, so the match succeeds and never backtracks —
+// every command silently truncates to its first line. Splitting the result per line is wrong too:
+// chat-flow's `-d` payload spans three lines inside one pair of single quotes, which the shell accepts.
+//
+// Method detection is deliberately loose. `-X PUT`, `-XPUT` and `--request PUT` are the same request,
+// and a command this reader fails to RECOGNISE is one it silently stops checking — which is worse than
+// a false positive, because the file-level precondition below is satisfied by any OTHER command in the
+// same README. A bare curl with no method is a GET and genuinely none of this check's business.
+function configPutCommands(text) {
+  return text
+    .replace(/\\\n\s*/g, ' ')
+    .split(/\n(?=\s*[$#]?\s*curl\b)/)
+    .filter((chunk) => /^\s*[$#]?\s*curl\b/.test(chunk))
+    .map((chunk) => chunk.split('```')[0])
+    .filter((cmd) => /\/plugins\/[^/\s"']+\/config\b/.test(cmd) && /(?:-X\s*|--request\s+)PUT\b/.test(cmd));
+}
+
+test('the config-curl reader recognises every spelling of the same request', () => {
+  const url = '"https://your-openwa-host/api/plugins/p/config"';
+  for (const cmd of [
+    `curl -X PUT ${url} -d '{}'`,
+    `curl -XPUT ${url} -d '{}'`,
+    `curl --request PUT ${url} -d '{}'`,
+    `$ curl -X PUT ${url} -d '{}'`,
+  ]) {
+    assert.equal(configPutCommands(cmd).length, 1, `not recognised: ${cmd}`);
+  }
+  // Reading the config back is a GET, and not this check's business.
+  assert.equal(configPutCommands(`curl ${url}`).length, 0);
+  // Both commands in one fence must be read, not just the first.
+  assert.equal(configPutCommands(`curl -X PUT ${url} -d '{}'\ncurl -XPUT ${url} -d '{}'`).length, 2);
+});
+
 test('every copy-pasteable config curl wraps its body in {"config": …}', () => {
   // `PUT /api/plugins/:id/config` takes `{ "config": { … } }`. A body with the fields at the root is
   // still well-formed JSON, so nothing rejects it locally — it just configures nothing. Sibling to the
@@ -129,22 +167,14 @@ test('every copy-pasteable config curl wraps its body in {"config": …}', () =>
   const offenders = [];
   for (const file of readmes) {
     const name = file.replace(root + '/', '');
-    // Join backslash continuations first, so each curl command lands on one line. Matching the command
-    // and its continuations in a single pattern does not work: the leading `[^\n]*` eats the trailing
-    // backslash, and because the continuation group may repeat zero times the match still succeeds — so
-    // the engine never backtracks and every command silently truncates to its first line.
-    // Splitting on newlines is not enough either: chat-flow's `-d` payload spans three lines inside one
-    // pair of single quotes, which the shell accepts and a per-line scan would truncate. Split on the
-    // start of the NEXT curl instead, then stop at the end of the code fence.
-    const joined = readFileSync(file, 'utf8').replace(/\\\n\s*/g, ' ');
-    for (const chunk of joined.split(/\n(?=\s*curl\b)/)) {
-      if (!/^\s*curl\b/.test(chunk)) continue;
-      const cmd = chunk.split('```')[0];
-      if (!/-X\s+PUT/.test(cmd) || !/\/plugins\/[^/\s"']+\/config\b/.test(cmd)) continue;
+    for (const cmd of configPutCommands(readFileSync(file, 'utf8'))) {
       withExample.add(file);
-      const body = /-d\s+'([^']*)'/.exec(cmd);
+      // `--data` is curl's own synonym for `-d`. Single quotes only: every command in the corpus uses
+      // them, and they are what keeps a JSON body free of shell escaping — so say that outright rather
+      // than reporting "no body" at a command that plainly has one.
+      const body = /(?:-d|--data(?:-raw)?)\s+'([^']*)'/.exec(cmd);
       if (!body) {
-        offenders.push(`${name}: PUT …/config carries no -d body`);
+        offenders.push(`${name}: PUT …/config has no single-quoted -d body for this check to read`);
         continue;
       }
       let parsed;
@@ -152,6 +182,11 @@ test('every copy-pasteable config curl wraps its body in {"config": …}', () =>
         parsed = JSON.parse(body[1]);
       } catch {
         offenders.push(`${name}: the -d body is not valid JSON`);
+        continue;
+      }
+      // A non-object body (a bare array or string) has no keys to inspect and cannot carry `config`.
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        offenders.push(`${name}: the -d body is ${Array.isArray(parsed) ? 'an array' : typeof parsed}, not a {"config": …} object`);
         continue;
       }
       if (!('config' in parsed)) offenders.push(`${name}: fields sit at the root (${Object.keys(parsed).join(', ')}) instead of under "config"`);

--- a/scripts/readme-claims.test.mjs
+++ b/scripts/readme-claims.test.mjs
@@ -121,6 +121,57 @@ test('every gateway URL in a README carries the /api prefix', () => {
   assert.deepEqual(offenders, []);
 });
 
+test('every copy-pasteable config curl wraps its body in {"config": …}', () => {
+  // `PUT /api/plugins/:id/config` takes `{ "config": { … } }`. A body with the fields at the root is
+  // still well-formed JSON, so nothing rejects it locally — it just configures nothing. Sibling to the
+  // /api check above: same failure shape (a curl that cannot be pasted), different half of the command.
+  const withExample = new Set();
+  const offenders = [];
+  for (const file of readmes) {
+    const name = file.replace(root + '/', '');
+    // Join backslash continuations first, so each curl command lands on one line. Matching the command
+    // and its continuations in a single pattern does not work: the leading `[^\n]*` eats the trailing
+    // backslash, and because the continuation group may repeat zero times the match still succeeds — so
+    // the engine never backtracks and every command silently truncates to its first line.
+    // Splitting on newlines is not enough either: chat-flow's `-d` payload spans three lines inside one
+    // pair of single quotes, which the shell accepts and a per-line scan would truncate. Split on the
+    // start of the NEXT curl instead, then stop at the end of the code fence.
+    const joined = readFileSync(file, 'utf8').replace(/\\\n\s*/g, ' ');
+    for (const chunk of joined.split(/\n(?=\s*curl\b)/)) {
+      if (!/^\s*curl\b/.test(chunk)) continue;
+      const cmd = chunk.split('```')[0];
+      if (!/-X\s+PUT/.test(cmd) || !/\/plugins\/[^/\s"']+\/config\b/.test(cmd)) continue;
+      withExample.add(file);
+      const body = /-d\s+'([^']*)'/.exec(cmd);
+      if (!body) {
+        offenders.push(`${name}: PUT …/config carries no -d body`);
+        continue;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(body[1]);
+      } catch {
+        offenders.push(`${name}: the -d body is not valid JSON`);
+        continue;
+      }
+      if (!('config' in parsed)) offenders.push(`${name}: fields sit at the root (${Object.keys(parsed).join(', ')}) instead of under "config"`);
+    }
+  }
+  assert.deepEqual(offenders, []);
+  // Enumerate what IS there. Should the command parsing above stop matching — a README switching to
+  // httpie, or wrapping the command differently — this check would otherwise stay green having examined
+  // nothing. The expectation is derived, not hand-listed: any README that names the config endpoint at
+  // all owes this check one command it can read. chatwoot-adapter names it nowhere (it is configured
+  // through `/integration/plugins/:id/instances`) and so is excluded by the corpus rather than by a list
+  // that would go stale.
+  const namesEndpoint = readmes.filter((f) => /\/plugins\/[^/\s"']+\/config\b/.test(readFileSync(f, 'utf8')));
+  assert.deepEqual(
+    namesEndpoint.filter((f) => !withExample.has(f)).map((f) => f.replace(root + '/', '')),
+    [],
+    'these READMEs name the config endpoint but show no PUT command this check can read',
+  );
+});
+
 test("a plugin README links the repository its manifest names", () => {
   // supabase-otp-hook was contributed from another account, and its Install section pointed at that
   // account's fork for the download. PR #54 corrected `repository` in the manifest — which is what the

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -106,7 +106,7 @@ curl -X POST http://localhost:2785/api/plugins/install \
 # Configure (per session, or '*' for all)
 curl -X PUT http://localhost:2785/api/plugins/voice-transcription/config \
   -H "X-API-Key: $OPENWA_API_KEY" -H 'Content-Type: application/json' \
-  -d '{"sttBaseUrl":"http://127.0.0.1:8000","model":"small","deliveryWebhookUrl":"http://127.0.0.1:5678/webhook/transcript"}'
+  -d '{ "config": { "sttBaseUrl": "http://127.0.0.1:8000", "model": "small", "deliveryWebhookUrl": "http://127.0.0.1:5678/webhook/transcript" } }'
 
 # Enable
 curl -X POST http://localhost:2785/api/plugins/voice-transcription/enable \


### PR DESCRIPTION
Six themed commits. The common thread is that several things this repo already checks carefully were reachable by paths that skipped those checks entirely, and two runtime limits were narrower than they looked.

## Release path

`ci.yml` runs on pushes and pull requests to `main` and has no tag trigger, so nothing ran the typecheck, the tests or the catalog check on the release path. A tag pushed at any commit produced a published zip, and that zip is installable the moment the Release is created. The release workflow now runs those checks before it packages anything.

## Packaging

`package.mjs` expands whatever `configUi.entry` names into the archive, collecting a directory entry recursively. An entry containing `..` therefore reached the repo root and pulled in the sibling plugins and `node_modules`. The entry is now resolved to a plain relative path inside the plugin directory, or refused outright.

Separately, the 5 MB size check ran *after* the archive had been written, so an oversized package was left behind on disk even though the build failed. It now runs against the buffer before the write.

## Loading a built bundle

`package.mjs` asserts that `main` is a member of the archive — not that the file can be required, nor that it exports what the host needs. A bundle that throws on load, or default-exports the wrong shape, was first discovered by the host at install time.

`scripts/loader-check.mjs` requires each built bundle, constructs the default export and asserts it has `onEnable()`. It runs in `ci.yml` across every plugin after the build loop, and in `release.yml` against the plugin being released, at the last point before the Release exists. It is also available locally as `npm run loader:check`, and takes an optional plugin id, filtered against discovery so a typo fails rather than passing silently.

## chatwoot-adapter — attachment uploads

The multipart boundary was built from the conversation id and the attachment's byte length, both of which a sender can work out from the media they send. An attachment crafted to contain that boundary could close its own part early and append parts of its own to the request reaching Chatwoot. The boundary is now 16 random bytes, matching the multipart producer already used in typebot-connector.

## gsheets-logger — buffer growth

`MAX_BUFFER` capped the row count alone, while `row.ts` allows 50,000 characters per cell across 14 columns, so the row cap by itself permitted a buffer far past the worker heap. Rows only accumulate that deep while Sheets is unreachable and the retain-on-failure path holds them. The buffer is now capped by total characters as well, dropping oldest first and keeping the newest row whatever its size.

`onDisable` persisted the buffer without handling a rejected `set`. Storage rejects once the plugin directory would exceed its quota, so the rejection escaped the lifecycle call itself and the number of rows that failed to persist went unreported.

## Documentation checks

voice-transcription's configuration example sent its fields at the root of the request body, while the endpoint expects them wrapped in `{"config": {...}}` — so the command failed when pasted. Every other README already used the wrapped form. A new check reads each `PUT .../config` command in the corpus and holds its body to that shape. The set of READMEs it must examine is derived from those that name the endpoint at all, so chatwoot-adapter, which is configured through a different endpoint, is excluded by the corpus rather than by a list that would go stale.

`catalog.test.mjs` had three checks iterating lists that can legitimately come back empty. Run that file against a tree with an empty `plugins.json` and no plugin directories and all three stay green having examined nothing. A precondition test now asserts those inputs once, the same shape `readme-claims.test.mjs` already uses.

## Verification

- 562 tests pass (553 before), typecheck clean, catalog up to date, and all 10 plugins build and load.
- Every commit is green on its own, checked commit by commit, so `git bisect` runs cleanly across the branch.
- The new checks were driven against real failures before being trusted: an escaping `configUi.entry` (refused, exit 1, no archive left on disk); bundles that throw on require, omit the default export, or are missing entirely (each refused, naming the plugin); and the config-body check run against the whole corpus, where it flagged only the README that was actually wrong.
