### PR TITLE
fix(build): refuse a symlink as an archive member

### DIFF
--- a/package.mjs
+++ b/package.mjs
@@ -1,10 +1,10 @@
 import { build } from 'esbuild';
-import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { zipStore } from './scripts/zip-store.mjs';
-import { configUiMember } from './scripts/entry-path.mjs';
+import { configUiMember, collectEntryFiles } from './scripts/entry-path.mjs';
 
 const plugin = process.argv[2];
 if (!plugin) {
@@ -76,15 +76,12 @@ if (manifest.configUi?.entry) {
   entries.push(member);
 }
 
-// Resolve each entry (file or directory) to zip members with forward-slash relative paths.
-function collectEntryFiles(base, rel) {
-  const abs = join(base, rel);
-  if (statSync(abs).isDirectory()) {
-    return readdirSync(abs, { withFileTypes: true }).flatMap((e) => collectEntryFiles(base, `${rel}/${e.name}`));
-  }
-  return [{ name: rel, data: readFileSync(abs) }];
+let result;
+try {
+  result = entries.flatMap((entry) => collectEntryFiles(dir, entry));
+} catch (e) {
+  fail(e.message);
 }
-const result = entries.flatMap((entry) => collectEntryFiles(dir, entry));
 
 // The archive members are chosen here, not read from the manifest, so a `main` pointing anywhere else
 // produces a package every gate in this repo accepts and the host refuses: it rejects an archive whose

--- a/scripts/entry-path.mjs
+++ b/scripts/entry-path.mjs
@@ -1,4 +1,5 @@
-import { isAbsolute, posix } from 'node:path';
+import { lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, posix } from 'node:path';
 
 // `configUi.entry` comes from a manifest, and the packager archives whatever it names — a directory
 // entry pulls in everything beneath it, recursively. Two things therefore have to hold: the entry must
@@ -23,4 +24,24 @@ export function configUiMember(entry) {
     throw new Error(`configUi.entry "${entry}" names the plugin directory itself — point it at the entry file`);
   }
   return segments[0];
+}
+
+// Resolve an entry to the archive members it contributes, as forward-slash relative paths.
+//
+// lstat, not stat: stat follows links, and a directory link inside a plugin pulls whatever it points
+// at into the archive — a `ui` link to a sibling directory put that directory's files into the zip,
+// contents and all, while the build reported success. Refusing links outright rather than resolving
+// and re-checking them is both simpler and more correct here: the archive stores file CONTENTS, so a
+// link would be flattened into a copy anyway, and an absolute one points at a path that exists only
+// on the machine that built it.
+export function collectEntryFiles(base, rel) {
+  const abs = join(base, rel);
+  const stat = lstatSync(abs);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`"${rel}" is a symlink — an archive member must be a real file inside the plugin`);
+  }
+  if (stat.isDirectory()) {
+    return readdirSync(abs, { withFileTypes: true }).flatMap((e) => collectEntryFiles(base, `${rel}/${e.name}`));
+  }
+  return [{ name: rel, data: readFileSync(abs) }];
 }

--- a/scripts/entry-path.test.mjs
+++ b/scripts/entry-path.test.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { configUiMember } from './entry-path.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { configUiMember, collectEntryFiles } from './entry-path.mjs';
 
 test('a configUi entry resolves to the top-level name the packager archives', () => {
   assert.equal(configUiMember('editor.html'), 'editor.html');
@@ -35,5 +38,39 @@ test('a configUi entry naming the plugin directory itself is refused, and says s
   // escaped the directory — it did not, it named the directory.
   for (const root of ['.', './', 'config/..', '']) {
     assert.throws(() => configUiMember(root), /names the plugin directory itself/, `expected "${root}" to be refused`);
+  }
+});
+
+test('a symlink inside the packaged tree is refused instead of followed out of the plugin', () => {
+  // statSync follows links, so a directory link inside a plugin pulls whatever it points at into the
+  // archive. Verified against the packager before this guard existed: a 'ui' link to a sibling
+  // directory put that directory's files into the zip, contents and all, and the build reported success.
+  const root = mkdtempSync(join(tmpdir(), 'entry-path-'));
+  try {
+    const plugin = join(root, 'plugin');
+    mkdirSync(join(plugin, 'config'), { recursive: true });
+    writeFileSync(join(plugin, 'config', 'index.html'), '<html></html>');
+    mkdirSync(join(root, 'outside'), { recursive: true });
+    writeFileSync(join(root, 'outside', 'keys.txt'), 'secret');
+
+    // A real file inside the plugin is collected as before.
+    assert.deepEqual(
+      collectEntryFiles(plugin, 'config').map((f) => f.name),
+      ['config/index.html'],
+    );
+
+    // A link that leaves the plugin, and a link that stays inside it: an archive member must be a real
+    // file either way, because the zip stores contents and an extracted link would not survive.
+    symlinkSync(join(root, 'outside'), join(plugin, 'ui'));
+    symlinkSync(join(plugin, 'config'), join(plugin, 'alias'));
+    for (const link of ['ui', 'alias']) {
+      assert.throws(() => collectEntryFiles(plugin, link), /symlink/, `expected "${link}" to be refused`);
+    }
+
+    // And one nested a level down, where the entry itself is an ordinary directory.
+    symlinkSync(join(root, 'outside'), join(plugin, 'config', 'nested'));
+    assert.throws(() => collectEntryFiles(plugin, 'config'), /symlink/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Collecting archive members used `statSync`, which follows symlinks. A directory link inside a plugin therefore pulled whatever it pointed at into the zip: a `ui` link to a sibling directory put that directory's files into the archive, contents and all, and the build reported success.

The entry string itself is perfectly ordinary in that case — `ui/index.html` names a relative path inside the plugin — so validating the entry could never have caught it. The escape happens on the filesystem, not in the manifest.

Members are now collected with `lstatSync`, and a link is refused wherever it appears: as the entry itself, or nested inside a directory being packaged. The message names the offending path.

Refusing rather than resolving is both simpler and more correct here. The archive stores file **contents**, so a link would be flattened into a copy regardless of where it pointed, and an absolute link names a path that exists only on the machine that built the package.

Collection also moved next to the entry validation it belongs with, so both halves of "what goes into the package" are covered by the same tests rather than one being untestable inside the packaging script.

## Verification

- Reproduced first: a `ui` link to a sibling directory produced a 5-member archive whose contents included a file from outside the plugin entirely. After the change both that case and a link nested one level deeper are refused, with no zip left on disk.
- 569 tests pass, typecheck clean, catalog up to date, all 10 plugins build and load.
- Artifacts are unchanged: `chat-flow`, `after-hours` and `gsheets-logger` rebuild byte-identical to `main`.
