### PR TITLE
fix(build): contribute each archive member once, and load the entry point the manifest names

### DIFF
--- a/package.mjs
+++ b/package.mjs
@@ -4,7 +4,7 @@ import { rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { zipStore } from './scripts/zip-store.mjs';
-import { configUiMember, collectEntryFiles } from './scripts/entry-path.mjs';
+import { configUiMember, collectMembers } from './scripts/entry-path.mjs';
 
 const plugin = process.argv[2];
 if (!plugin) {
@@ -78,7 +78,7 @@ if (manifest.configUi?.entry) {
 
 let result;
 try {
-  result = entries.flatMap((entry) => collectEntryFiles(dir, entry));
+  result = collectMembers(dir, entries);
 } catch (e) {
   fail(e.message);
 }

--- a/scripts/entry-path.mjs
+++ b/scripts/entry-path.mjs
@@ -45,3 +45,15 @@ export function collectEntryFiles(base, rel) {
   }
   return [{ name: rel, data: readFileSync(abs) }];
 }
+
+// Collect every entry into one member list, keyed by archive path so overlapping entries contribute
+// each file once. They do overlap: configUiMember returns the TOP-LEVEL name, so a configUi entry of
+// 'dist/ui.html' adds 'dist' to a list that already names 'dist/index.js' and 'dist/package.json'.
+// A member's name determines its content, so collapsing by name cannot lose anything.
+export function collectMembers(base, entries) {
+  const byName = new Map();
+  for (const entry of entries) {
+    for (const file of collectEntryFiles(base, entry)) byName.set(file.name, file);
+  }
+  return [...byName.values()];
+}

--- a/scripts/entry-path.test.mjs
+++ b/scripts/entry-path.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { configUiMember, collectEntryFiles } from './entry-path.mjs';
+import { configUiMember, collectEntryFiles, collectMembers } from './entry-path.mjs';
 
 test('a configUi entry resolves to the top-level name the packager archives', () => {
   assert.equal(configUiMember('editor.html'), 'editor.html');
@@ -70,6 +70,26 @@ test('a symlink inside the packaged tree is refused instead of followed out of t
     // And one nested a level down, where the entry itself is an ordinary directory.
     symlinkSync(join(root, 'outside'), join(plugin, 'config', 'nested'));
     assert.throws(() => collectEntryFiles(plugin, 'config'), /symlink/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an entry nested under another entry contributes each member once', () => {
+  // configUiMember returns the TOP-LEVEL name, so a configUi entry of 'dist/ui.html' adds 'dist' to a
+  // list that already names 'dist/index.js' and 'dist/package.json' — and the archive then carried
+  // each of those twice. Extractors do not agree on what a duplicate name means, and the size check
+  // counts the bytes twice either way.
+  const root = mkdtempSync(join(tmpdir(), 'entry-members-'));
+  try {
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'manifest.json'), '{}');
+    writeFileSync(join(root, 'dist', 'index.js'), 'bundle');
+    writeFileSync(join(root, 'dist', 'ui.html'), '<html></html>');
+
+    const names = collectMembers(root, ['manifest.json', 'dist/index.js', 'dist']).map((f) => f.name);
+    assert.deepEqual([...names].sort(), ['dist/index.js', 'dist/ui.html', 'manifest.json']);
+    assert.equal(new Set(names).size, names.length, `duplicate members: ${names.join(', ')}`);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/loader-check.mjs
+++ b/scripts/loader-check.mjs
@@ -3,7 +3,7 @@
 // needs. So a bundle that throws on require — or default-exports the wrong shape — is first discovered
 // by the host at install, after the tag and the GitHub Release are already published. Run after a build.
 import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { discoverPluginDirs } from './run-tests.mjs';
@@ -13,7 +13,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 export function assertLoadable(mod, id) {
   const Plugin = mod?.default;
   if (typeof Plugin !== 'function') {
-    throw new Error(`${id}: dist/index.js does not default-export a constructor (got ${typeof Plugin})`);
+    throw new Error(`${id}: the built bundle does not default-export a constructor (got ${typeof Plugin})`);
   }
   let instance;
   try {
@@ -49,9 +49,13 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
   const failures = [];
   let handles = process.getActiveResourcesInfo().length;
   for (const id of dirs) {
-    const bundle = join(ROOT, id, 'dist', 'index.js');
+    // Load what `main` names, not a hard-coded path: `main` is the file the host requires at install,
+    // and it is the one package.mjs asserts is in the archive. Checking a different file would leave
+    // the published entry point untested while reporting success.
+    const main = JSON.parse(readFileSync(join(ROOT, id, 'manifest.json'), 'utf8')).main;
+    const bundle = join(ROOT, id, main);
     if (!existsSync(bundle)) {
-      failures.push(`${id}: dist/index.js is missing — run \`npm run build\` first`);
+      failures.push(`${id}: ${main} is missing — run \`npm run build\` first`);
       continue;
     }
     // require() is separated from the shape check so a bundle that throws on load is still reported
@@ -60,7 +64,7 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     try {
       mod = require(bundle);
     } catch (err) {
-      failures.push(`${id}: dist/index.js threw on require — ${err.message}`);
+      failures.push(`${id}: the built bundle threw on require — ${err.message}`);
       continue;
     }
     try {


### PR DESCRIPTION
Two packaging defects that only surface on a configuration no plugin uses today, which is exactly why they had gone unnoticed.

## Duplicate archive members

Entries can overlap. `configUiMember` returns the **top-level** name, so a configUi entry of `dist/ui.html` adds `dist` to a list that already names `dist/index.js` and `dist/package.json`. The archive then carried each of those twice — verified: a six-member zip where four were expected.

Extractors do not agree on what a duplicate name means, and the 5 MB limit counted the duplicated bytes either way. Members are now collected into one map keyed by archive path; a member's name determines its content, so collapsing by name cannot lose anything.

## The loader check tested the wrong file

The check required a hard-coded `dist/index.js`. That is the path all ten plugins happen to use, but it is not the one the host loads: the host requires whatever `main` names, and `main` is also the field `package.mjs` asserts is present in the archive.

So a plugin whose `main` pointed elsewhere would be reported as missing its bundle — or worse, checked against a stale `dist/index.js` left from an earlier build while its real entry point went untested and the gate reported success. The check now reads `main` from the manifest, and its messages name that file.

## Verification

- Reproduced both first. A configUi entry under `dist/` produced a six-member archive; it now produces four. A plugin with `main: "dist/plugin.js"` and no `dist/index.js` was previously unverifiable; it now passes when healthy, is caught when its default export is wrong, and reports `dist/plugin.js is missing` rather than a file it never used.
- 570 tests pass, typecheck clean, catalog up to date, all 10 plugins build and load.
- Artifacts unchanged: `chat-flow`, `after-hours` and `chatwoot-adapter` rebuild byte-identical to `main`.
