### PR TITLE
fix: bound the group-translate skip filter and scope the chatwoot reply mapping

### DIFF
--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ### Fixed
 
+- **An agent reply can no longer reach the wrong customer.** Chatwoot conversation ids are per-account
+  autoincrement, so two relayed accounts share one routinely. Alongside the tenant-scoped reverse
+  mapping, an unscoped one was rewritten on every link, leaving it pointing at whichever session linked
+  last — a delivery that arrived without a session scope resolved through it and was sent to that
+  session's chat. The unscoped mapping is now claimed only while unclaimed and marked unusable once a
+  second session claims the same id, so such a delivery is dropped and logged rather than guessed.
+  Mappings written before scoping keep resolving, and single-tenant hosts are unaffected.
+- **Recovering one session no longer drops another session's replies.** Unlinking by conversation id
+  deleted the shared unscoped mapping as well, silently breaking the other tenant until its next
+  inbound message. It is now removed only when it belongs to the session being unlinked.
+
 - **Attachment uploads now use an unpredictable multipart boundary.** The boundary was built from the
   conversation id and the file's byte length, both of which a sender can work out from the media they
   send — so an attachment crafted to contain that exact boundary could close the part early and append

--- a/chatwoot-adapter/echo-loop.test.ts
+++ b/chatwoot-adapter/echo-loop.test.ts
@@ -172,15 +172,15 @@ test("one tenant's mirror marker does not suppress another tenant's reply with t
   assert.equal(posted.length, 1);
 
   // Tenant B's agent now replies, and Chatwoot happens to number THAT message 60 as well. The delivery
-  // is UNSCOPED, which is what makes this bite: a guard that keyed the marker on the delivery scope would
-  // fall back to a global `seen:cw:60` and find tenant A's marker sitting there.
+  // carries B's scope, so the marker lookup is `seen:sessB:cw:60` and tenant A's marker cannot reach it.
+  // A guard keyed on the bare id would fall back to a global `seen:cw:60` and find A's marker there.
   const sent: Array<{ chatId?: string }> = [];
   const outboundB = {
     lock, store, engine, inboxId: INBOX_ID, log: () => {},
     conversations: { send: async (e: { chatId?: string }) => { sent.push(e); return { messageId: 'wa-b' }; } },
     handover: { set: async () => {} },
   } as unknown as OutboundDeps;
-  await handleOutbound(outboundB, mirrorWebhook(60, undefined));
+  await handleOutbound(outboundB, mirrorWebhook(60, 'sessB'));
 
   assert.equal(sent.length, 1, "tenant B's genuine reply was suppressed by tenant A's echo marker");
   assert.equal(sent[0].chatId, 'bob@c.us');
@@ -230,4 +230,32 @@ test('an echo webhook processed while the adapter post is still in flight is NOT
   await Promise.all([relayPromise, echoPromise]);
 
   assert.deepEqual(sent, [], 'the echo was processed before the marker landed and got re-sent to WhatsApp');
+});
+
+test('a scope-less delivery for a conversation id two tenants claim is dropped, not guessed', async () => {
+  // Chatwoot conversation ids are per-account autoincrement, so two relayed accounts collide on one as a
+  // matter of course. The unscoped reverse key used to hold whichever session linked last, so a delivery
+  // without a session scope resolved to that one — an agent reply for one customer delivered to another
+  // customer's number. Nothing in a scope-less delivery says which tenant it belongs to, so there is no
+  // right answer to pick; dropping it is the only safe outcome, and the adapter logs the miss.
+  const store = new MappingStore(fakeStorage(), fakeMappings);
+  const lock = new KeyedAsyncLock();
+  const engine = { canonicalChatId: async (_s: string, c: string) => c };
+  await store.link('sessA', 'alice@c.us', 'instA', { conversationId: 55, contactId: 1, sourceId: 'a' });
+  await store.link('sessB', 'bob@c.us', 'instB', { conversationId: 55, contactId: 2, sourceId: 'b' });
+
+  const sent: Array<{ chatId?: string }> = [];
+  const deps = {
+    lock, store, engine, inboxId: INBOX_ID, log: () => {},
+    conversations: { send: async (e: { chatId?: string }) => { sent.push(e); return { messageId: 'x' }; } },
+    handover: { set: async () => {} },
+  } as unknown as OutboundDeps;
+
+  await handleOutbound(deps, mirrorWebhook(61, undefined));
+  assert.deepEqual(sent, [], 'a scope-less delivery must never be routed to a guessed tenant');
+
+  // A single-tenant mapping is unaffected: the unscoped key is still claimed and still resolves.
+  const solo = new MappingStore(fakeStorage(), fakeMappings);
+  await solo.link('sessOnly', 'solo@c.us', 'inst', { conversationId: 55, contactId: 3, sourceId: 's' });
+  assert.deepEqual(await solo.getByConversation(55), { sessionId: 'sessOnly', chatId: 'solo@c.us' });
 });

--- a/chatwoot-adapter/mapping-store.test.ts
+++ b/chatwoot-adapter/mapping-store.test.ts
@@ -237,3 +237,53 @@ test('a failed prune listing does not stop pre-0.6.0 markers being honoured', as
   assert.equal(await store.hasSeen('cw', '4242', 'sess'), true,
     'the legacy marker must still be found after a prune that saw an empty listing');
 });
+
+test('two sessions sharing a conversation id resolve to their own chat', async () => {
+  // Chatwoot conversation ids are per-account autoincrement, so two accounts relayed by one gateway
+  // collide as a matter of course. The unscoped reverse key was written on every link, so the last
+  // writer won it — and a delivery resolving through it sent one customer's agent reply to another
+  // customer's number.
+  const store = new MappingStore(fakeStorage(), fakeMappings());
+  await store.link('sess-A', '628111@c.us', 'inst', { conversationId: 42, contactId: 1, sourceId: 'a' });
+  await store.link('sess-B', '628222@c.us', 'inst', { conversationId: 42, contactId: 2, sourceId: 'b' });
+
+  assert.deepEqual(await store.getByConversation(42, 'sess-A'), { sessionId: 'sess-A', chatId: '628111@c.us' });
+  assert.deepEqual(await store.getByConversation(42, 'sess-B'), { sessionId: 'sess-B', chatId: '628222@c.us' });
+});
+
+test('unlinking one session leaves another session mapping intact', async () => {
+  // The 404 recovery path unlinks by conversation id. It deleted the shared unscoped key too, so
+  // recovering tenant A silently dropped tenant B's agent replies until B's next inbound message.
+  const store = new MappingStore(fakeStorage(), fakeMappings());
+  await store.link('sess-A', '628111@c.us', 'inst', { conversationId: 42, contactId: 1, sourceId: 'a' });
+  await store.link('sess-B', '628222@c.us', 'inst', { conversationId: 42, contactId: 2, sourceId: 'b' });
+
+  await store.unlinkByConversationId('sess-A', 42);
+
+  assert.equal(await store.getByConversation(42, 'sess-A'), null);
+  assert.deepEqual(await store.getByConversation(42, 'sess-B'), { sessionId: 'sess-B', chatId: '628222@c.us' });
+});
+
+test('a reverse mapping written before scoping still resolves', async () => {
+  // Back-compat: data already on disk uses the unscoped key. It must keep resolving, otherwise an
+  // upgrade silently breaks every existing conversation.
+  const storage = fakeStorage();
+  await storage.set('wa:77', { sessionId: 'sess-old', chatId: '628999@c.us' });
+  const store = new MappingStore(storage, fakeMappings());
+
+  assert.deepEqual(await store.getByConversation(77, 'sess-old'), { sessionId: 'sess-old', chatId: '628999@c.us' });
+  assert.deepEqual(await store.getByConversation(77), { sessionId: 'sess-old', chatId: '628999@c.us' });
+});
+
+test('a conversation id claimed by two sessions never resolves without a scope', async () => {
+  // A delivery that carries no session scope carries no information about which tenant it belongs to.
+  // The unscoped reverse key was written on every link, so it held whichever session linked last and a
+  // scope-less delivery resolved to that one — sending an agent reply for one customer to a different
+  // customer's number. When two sessions claim the same conversation id there is no right answer to
+  // guess, and dropping the delivery is the only safe one.
+  const store = new MappingStore(fakeStorage(), fakeMappings());
+  await store.link('sess-A', '628111@c.us', 'inst', { conversationId: 42, contactId: 1, sourceId: 'a' });
+  await store.link('sess-B', '628222@c.us', 'inst', { conversationId: 42, contactId: 2, sourceId: 'b' });
+
+  assert.equal(await store.getByConversation(42), null);
+});

--- a/chatwoot-adapter/mapping-store.ts
+++ b/chatwoot-adapter/mapping-store.ts
@@ -36,8 +36,10 @@ export interface ChatLink {
 // (shared across every session/instance), and Chatwoot conversation + message ids are per-account
 // autoincrement, so anything keyed by id alone collides across tenants. The reverse map and dedup markers
 // are therefore scoped by the WA sessionId (the one identity both the inbound hook and the outbound
-// ingress delivery share). A session-scoped legacy reverse key is ALSO written so a delivery that arrives
-// without a session scope (or a pre-scope row) still resolves — unscoped, so single-tenant is unaffected.
+// ingress delivery share). An UNSCOPED reverse key is kept for deliveries that arrive without a session
+// scope and for rows written before scoping existed. It is claimed only while unclaimed: once a second
+// session links the same conversation id it is marked ambiguous, because whichever session wrote it last
+// would otherwise receive the other one's agent replies. Single-tenant hosts are unaffected.
 // Retention window for `seen:` de-dup markers, and how often expired ones are pruned. Hardcoded (mirroring
 // the retry-timer constants in retry.ts) — a generous default that outlasts any realistic WhatsApp message
 // re-delivery, so pruning never re-posts a duplicate. Bumping the TTL is a one-line change.
@@ -72,6 +74,9 @@ export function shardOf(logicalId: string): number {
 
 // One bucket: logical marker id -> first-seen wall-clock ms.
 type SeenBucket = Record<string, number>;
+
+/** The unscoped reverse mapping: a session's chat, or a marker that two sessions claim this id. */
+type LegacyRev = { sessionId: string; chatId: string } | { ambiguous: true };
 
 export class MappingStore {
 
@@ -134,14 +139,28 @@ export class MappingStore {
       const scoped = await this.storage.get<{ sessionId: string; chatId: string }>(this.revKey(sessionId, conversationId));
       if (scoped) return scoped;
     }
-    return this.storage.get<{ sessionId: string; chatId: string }>(this.legacyRevKey(conversationId));
+    const legacy = await this.storage.get<LegacyRev>(this.legacyRevKey(conversationId));
+    // Marked once a second session claimed the same conversation id. A scope-less delivery carries
+    // nothing that says which tenant it belongs to, so there is no right answer to pick here.
+    if (!legacy || 'ambiguous' in legacy) return null;
+    return legacy;
   }
 
   async link(sessionId: string, chatId: string, instanceId: string, link: ChatLink): Promise<void> {
     await this.storage.set(this.fwdKey(sessionId, chatId), link);
     const rev = { sessionId, chatId };
     await this.storage.set(this.revKey(sessionId, link.conversationId), rev); // tenant-scoped lookup
-    await this.storage.set(this.legacyRevKey(link.conversationId), rev); // back-compat for scope-less deliveries
+    // The unscoped key exists only so mappings written before scoping keep resolving. A Chatwoot
+    // conversation id is unique per ACCOUNT, not per gateway, so two relayed accounts collide on it as
+    // a matter of course — and whoever linked last used to win the key. Claim it only while it is
+    // unclaimed, and mark it unusable once a second session claims the same id.
+    const legacyKey = this.legacyRevKey(link.conversationId);
+    const legacy = await this.storage.get<LegacyRev>(legacyKey);
+    if (!legacy) {
+      await this.storage.set(legacyKey, rev);
+    } else if (!('ambiguous' in legacy) && legacy.sessionId !== sessionId) {
+      await this.storage.set(legacyKey, { ambiguous: true });
+    }
     await this.mappings.upsert({ sessionId, chatId, instanceId }, String(link.conversationId));
   }
 
@@ -309,6 +328,11 @@ export class MappingStore {
 
   async unlinkByConversationId(sessionId: string, conversationId: number) {
     await this.storage.delete(this.revKey(sessionId, conversationId));
-    await this.storage.delete(this.legacyRevKey(conversationId));
+    // Only if it is ours. Deleting it unconditionally removed another tenant's fallback along with
+    // our own, silently dropping their agent replies until their next inbound message rebuilt it.
+    const legacy = await this.storage.get<LegacyRev>(this.legacyRevKey(conversationId));
+    if (legacy && !('ambiguous' in legacy) && legacy.sessionId === sessionId) {
+      await this.storage.delete(this.legacyRevKey(conversationId));
+    }
   }
 }

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,18 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A group message can no longer stall the plugin worker.** The filter that skips messages with
+  nothing to translate was a single regular expression whose emoji branch overlapped its URL branch —
+  `\p{Emoji}` matches ASCII digits, `#` and `*`, because those are keycap-sequence components. Each
+  additional link-shaped token multiplied the backtracking space, so a 145-character message took
+  several seconds of uninterruptible CPU and `maxLength` allows 2000. The filter now scans token by
+  token, which is linear regardless of input.
+- **A message of only digits or punctuation is translated again.** The same emoji property classified
+  `1` and `#5` as emoji, so those messages were skipped silently. The filter now uses
+  `\p{Extended_Pictographic}`, which is the property that actually means "picture character".
+
 ## [1.3.1] — 2026-08-12
 
 ### Changed

--- a/group-translate/core/translation.coordinator.test.ts
+++ b/group-translate/core/translation.coordinator.test.ts
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { TranslationCoordinator, CoordinatorOptions } from './translation.coordinator';
+import { TranslationCoordinator, CoordinatorOptions, isUrlOrEmojiOnly } from './translation.coordinator';
 import { ChatGateway, ConfigStore, GroupState, InboundMessage, Translator, TranslationLogger } from './ports';
 
 // The shipped defaults, so every test below runs against what an operator actually gets.
@@ -630,4 +630,29 @@ describe('TranslationCoordinator', () => {
     ]);
     assert.equal(sends.length, 1, 'the help announcement must be sent once, not duplicated by a load/save race');
   });
+});
+
+test('the skip filter stays linear on adversarial input', () => {
+  // The filter was /^(?:\s|\p{Emoji}|https?:\/\/\S+)+$/u. `\p{Emoji}` matches ASCII digits, `#` and `*`
+  // — they are keycap-sequence components — so it overlapped `\S+` in the URL branch and every extra
+  // token multiplied the backtracking space. Measured on the real pattern: nine tokens over 145
+  // characters took 5.5 s, while the same payload with letters took 0.0 ms. maxLength defaults to 2000,
+  // and any member of a group with /tr on could send it. JS regex execution cannot be interrupted, so
+  // this held the worker's event loop outright.
+  const payload = `${Array(9).fill('http://11111111').join(' ')} a`;
+  const started = performance.now();
+  const skip = isUrlOrEmojiOnly(payload);
+  const elapsed = performance.now() - started;
+
+  assert.equal(skip, false, 'the trailing word makes this translatable, not skippable');
+  assert.ok(elapsed < 100, `filter took ${elapsed.toFixed(1)} ms on ${payload.length} characters`);
+});
+
+test('the skip filter still recognises what it is meant to skip', () => {
+  for (const skippable of ['https://example.com', 'http://a.co https://b.co', '👍', '👍 🎉', '   ', 'https://a.co 👍']) {
+    assert.equal(isUrlOrEmojiOnly(skippable), true, `should skip: ${JSON.stringify(skippable)}`);
+  }
+  for (const translatable of ['hello', 'https://a.co and text', 'lihat https://a.co ya', '1', 'halo 👍']) {
+    assert.equal(isUrlOrEmojiOnly(translatable), false, `should translate: ${JSON.stringify(translatable)}`);
+  }
 });

--- a/group-translate/core/translation.coordinator.ts
+++ b/group-translate/core/translation.coordinator.ts
@@ -24,7 +24,27 @@ export interface CoordinatorOptions {
   announceInGroups: boolean;
 }
 
-const URL_OR_EMOJI_ONLY = /^(?:\s|\p{Emoji}|https?:\/\/\S+)+$/u;
+// One token that is nothing but picture characters — pictographic base, skin-tone modifier, variation
+// selector, or the zero-width joiner that binds a composite emoji together.
+const EMOJI_RUN = /^[\p{Extended_Pictographic}\p{Emoji_Modifier}️‍]+$/u;
+
+/**
+ * True when a message carries nothing worth translating: whitespace, links, emoji, or a mix.
+ *
+ * Scanned token by token rather than matched as one pattern. The previous form,
+ * `/^(?:\s|\p{Emoji}|https?:\/\/\S+)+$/u`, backtracked catastrophically — `\p{Emoji}` matches ASCII
+ * digits, `#` and `*` (they are keycap-sequence components), so it overlapped `\S+` in the URL branch
+ * and every additional token multiplied the search space. 145 characters took seconds, and `maxLength`
+ * allows 2000. `\p{Extended_Pictographic}` is the property that actually means "picture character",
+ * which also stops a message of "1" from being classed as emoji and silently left untranslated.
+ */
+export function isUrlOrEmojiOnly(text: string): boolean {
+  const tokens = text.split(/\s+/).filter((token) => token !== '');
+  if (tokens.length === 0) return true;
+  return tokens.every(
+    (token) => token.startsWith('http://') || token.startsWith('https://') || EMOJI_RUN.test(token),
+  );
+}
 
 /** Object keys that index the prototype chain rather than an own property; never valid as a wid. */
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -103,7 +123,7 @@ export class TranslationCoordinator {
 
   private async translateMessage(sessionId: string, msg: InboundMessage, state: GroupState): Promise<void> {
     const text = msg.body.trim();
-    if (text.length < this.opts.minLength || text.length > this.opts.maxLength || URL_OR_EMOJI_ONLY.test(text)) {
+    if (text.length < this.opts.minLength || text.length > this.opts.maxLength || isUrlOrEmojiOnly(text)) {
       return;
     }
 


### PR DESCRIPTION
Two defects on the message path, both reachable from ordinary traffic and both reproduced before being fixed.

## group-translate — a group message could stall the plugin worker

The filter that skips messages with nothing to translate was one regular expression:

```
/^(?:\s|\p{Emoji}|https?:\/\/\S+)+$/u
```

`\p{Emoji}` matches ASCII digits, `#` and `*` — they are keycap-sequence components — so the emoji branch also matched the `\S+` inside the URL branch. Every additional link-shaped token multiplied the backtracking space:

| tokens | length | `test()` |
|---|---|---|
| 6 | 97 | 70 ms |
| 7 | 113 | 174 ms |
| 8 | 129 | 811 ms |
| 9 | 145 | 5 526 ms |

The identical payload written with letters instead of digits completes in 0.0 ms, which isolates the cause. `maxLength` defaults to 2000 characters, JavaScript regex execution cannot be interrupted, and any member of a group with translation on could send such a message — so the time is spent holding the worker's event loop outright.

The filter now splits on whitespace and checks each token, which is linear and needs no backtracking. Same input: **5 526 ms → 0.08 ms**, and flat at 3200 characters.

Switching the emoji test to `\p{Extended_Pictographic}` — the property that actually means "picture character" — fixes a second consequence of the same overlap: a message of `1` or `#5` was classed as emoji-only and silently left untranslated.

## chatwoot-adapter — an agent reply could reach the wrong customer

Chatwoot conversation ids are per-account autoincrement, so two accounts relayed by one gateway share one routinely. Beside the tenant-scoped reverse mapping (`wa:<session>:<id>`), an unscoped one (`wa:<id>`) was rewritten on **every** link, so it held whichever session linked last. A delivery that arrived without a session scope resolved through it and was sent to that session's chat — one customer's agent reply delivered to another customer's number.

Unlinking by conversation id, which the 404 recovery path does, deleted that shared mapping as well — silently dropping the other tenant's replies until their next inbound message rebuilt it.

The unscoped mapping is now claimed only while it is unclaimed, and marked unusable once a second session claims the same id. Nothing in a scope-less delivery identifies its tenant, so there is no right answer to guess: it is dropped and logged instead. Unlink removes the mapping only when it belongs to the session being unlinked.

**Compatibility.** Mappings written before scoping keep resolving, and a single-tenant host is unaffected — the unscoped key is still claimed and still used. One echo-loop test relied on the old guess; it now supplies the session scope such a delivery carries in practice, which is what it meant to exercise, and a new test pins the drop.

## Verification

- 577 tests pass, typecheck clean, catalog up to date, all 10 plugins build and load.
- Both fixes are test-first: the filter test failed at 2 983 ms before the change, and the mapping test resolved to the wrong tenant.
