### PR TITLE
fix: tighten the debug logging, rule-pattern and ingress guards

### DIFF
--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,15 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two rule patterns that could freeze the plugin are now rejected.** The safety analyser reasoned that
+  a small bounded repeat is bounded by its constant, which holds for a variable-width body but not for an
+  unbounded one: `(a+){3}` expands to `a+a+a+` and backtracks exponentially. It also treated any group as
+  breaking a run of adjacent unbounded quantifiers, but a group that can match empty does not — so
+  `.*(x?).*(x?).*` was `.*.*.*` in disguise. Both are refused now. Patterns of the shape `(ab?){2}` and
+  `.*(x).*(y).*`, which really are bounded, are still accepted.
+
 ## [0.2.1] — 2026-08-01
 
 No behaviour change. 0.2.0 has now been smoke-tested against a newer host, so the tested-version field

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseRules, matchRule } from './rules.ts';
+import { parseRules, matchRule, isSafeRegexPattern } from './rules.ts';
 
 const ok = JSON.stringify([
   { mode: 'contains', pattern: 'harga', reply: 'Harga mulai 100rb' },
@@ -194,4 +194,27 @@ test('matchRule: exact trims + case-insensitive; regex uses the i flag', () => {
   assert.equal(matchRule(rules, '  MENU ')?.reply, 'Menu: 1) Harga 2) Jam');
   assert.equal(matchRule(rules, '/START now')?.reply, 'Selamat datang');
   assert.equal(matchRule(rules, 'nothing here'), null);
+});
+
+test('a bounded repeat of an unbounded body is rejected', () => {
+  // The doc reasoned that a small bounded repeat is "bounded by the constant and safe". That holds for a
+  // variable-width body, not for an unbounded one: `(a+){3}` expands to `a+a+a+`, which backtracks
+  // exponentially. Measured before this case was closed: 200 characters took 1.4 s, 1000 took over 6 s.
+  for (const pattern of ['(a+){3}b', '(a+){2}b', '(\\w+){4}!', '(a*){3}b']) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // A bounded repeat of a VARIABLE body stays allowed — that is the case the constant really does bound.
+  assert.equal(isSafeRegexPattern('(ab?){2}'), true);
+  assert.equal(isSafeRegexPattern('(abc){5}'), true);
+});
+
+test('a nullable group does not break a run of adjacent unbounded quantifiers', () => {
+  // Rule 2 treats a group boundary as breaking adjacency, which is true only when the group must consume
+  // something. `(x?)` can match empty, so `.*(x?).*(x?).*` is `.*.*.*` wearing a disguise — three
+  // adjacent unbounded quantifiers over overlapping atoms. Measured: 1000 characters took over 6 s.
+  for (const pattern of ['.*(x?).*(x?).*!', '.*(x*).*(x*).*!', '\\w*(a?)\\w*(a?)\\w*!']) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // A group that must consume still breaks the run, which is what makes these patterns safe.
+  assert.equal(isSafeRegexPattern('.*(x).*(y).*!'), true);
 });

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -76,13 +76,14 @@ const REPEAT_THRESHOLD = 10;
  *     `.*.*.*`, `\w*\w*\w*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only O(n^2), safe under the
  *     1000-char input cap, so it is allowed; a mandatory atom or a group boundary breaks the chain;
  *  3. an unbounded or ≥REPEAT_THRESHOLD repeat of a group whose body has a variable-width quantifier —
- *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat like `(ab?){2}` is allowed.
+ *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat of a VARIABLE body like `(ab?){2}` is
+ *     allowed, but any repeat of an UNBOUNDED body is not — see (1).
  * Character classes follow JS semantics (`[]` empty, `[^]` any). Accepted patterns run on the native engine
  * unchanged. Overlapping-alternation (`(a|a)*`) is still not modelled — a documented residual. Fails closed.
  */
 export function isSafeRegexPattern(p: string): boolean {
   if (p.length > MAX_PATTERN_LENGTH) return false;
-  const stack: { hasUnbounded: boolean; hasVariable: boolean }[] = [];
+  const stack: { hasUnbounded: boolean; hasVariable: boolean; savedPrev: string | null; savedRun: number }[] = [];
   // Rule 2 state: the key of the previous unbounded-quantified atom in the current flat concatenation,
   // or null after a mandatory atom / `|` / group boundary (which break adjacency).
   let prevUnbounded: string | null = null;
@@ -93,22 +94,30 @@ export function isSafeRegexPattern(p: string): boolean {
 
     if (c === '|') { prevUnbounded = null; adjacentRun = 0; i++; continue; }
     if (c === '(') {
-      stack.push({ hasUnbounded: false, hasVariable: false });
+      // The run so far is parked, not discarded: whether this group breaks it depends on whether it can
+      // match empty, which is only known at the closing paren.
+      stack.push({ hasUnbounded: false, hasVariable: false, savedPrev: prevUnbounded, savedRun: adjacentRun });
       prevUnbounded = null; adjacentRun = 0;
       i++;
       if (p[i] === '?') { i++; if (p[i] === '<') i++; if (p[i] === ':' || p[i] === '=' || p[i] === '!') i++; }
       continue;
     }
     if (c === ')') {
-      const frame = stack.pop() ?? { hasUnbounded: false, hasVariable: false };
+      const frame = stack.pop() ?? { hasUnbounded: false, hasVariable: false, savedPrev: null, savedRun: 0 };
       const q = quantifierAt(p, i + 1);
-      if (q.unbounded && frame.hasUnbounded) return false; // (1) nested unbounded
+      // (1) nested unbounded. A BOUNDED repeat counts too once it repeats at all: `(a+){3}` expands to
+      // `a+a+a+`, which backtracks exponentially — the constant bounds the repeat, not the search.
+      if ((q.unbounded || q.count >= 2) && frame.hasUnbounded) return false;
       if (q.count >= REPEAT_THRESHOLD && frame.hasVariable) return false; // (3) large/unbounded repeat of a variable body
       if (stack.length) {
         if (q.unbounded || frame.hasUnbounded) stack[stack.length - 1].hasUnbounded = true;
         if (q.variable || frame.hasVariable) stack[stack.length - 1].hasVariable = true;
       }
-      prevUnbounded = null; adjacentRun = 0; // a group boundary breaks flat adjacency (Rule 2)
+      // A group breaks flat adjacency only if it MUST consume something. `(x?)` can match empty, so
+      // `.*(x?).*` is `.*.*` in disguise; resume the parked run rather than pretending it ended.
+      const nullable = frame.hasVariable || q.unbounded || (q.present && q.min === 0);
+      if (nullable) { prevUnbounded = frame.savedPrev; adjacentRun = frame.savedRun; }
+      else { prevUnbounded = null; adjacentRun = 0; }
       i += 1 + q.len;
       continue;
     }

--- a/scripts/catalog.mjs
+++ b/scripts/catalog.mjs
@@ -57,6 +57,15 @@ function validateManifest(id, manifest) {
       );
     }
   }
+  // An ingress route is a public endpoint once the host provisions it, and the host refuses to load a
+  // plugin that declares one without the permission — but only at install, on the operator's gateway,
+  // after the release is published. Catch it where the catalogue is built instead.
+  if (Array.isArray(manifest.ingress) && manifest.ingress.length && !(manifest.permissions ?? []).includes('webhook:ingress')) {
+    throw new Error(
+      `${id}: declares ${manifest.ingress.length} ingress route(s) but not the "webhook:ingress" permission — ` +
+        `the host refuses to load such a plugin`,
+    );
+  }
   if (!manifest.i18n || Object.keys(manifest.i18n).length === 0) {
     console.warn(`⚠ ${id}: no i18n block — dashboard shows English only`);
   } else {

--- a/supabase-otp-hook/CHANGELOG.md
+++ b/supabase-otp-hook/CHANGELOG.md
@@ -9,6 +9,15 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Debug mode no longer writes the verification code or the destination number to the log.** Debug is
+  switched on precisely when a delivery is misbehaving, so its output is what gets pasted into a support
+  thread or shipped to a log collector — and an OTP is a live credential with the number beside it
+  naming its owner. The send line now records the message length instead of the message, and every chat
+  id in a log line is reduced to its last four digits, which is enough to correlate two lines about the
+  same chat.
+
+### Fixed
+
 - **The README no longer promises a dead-session `503` that Option B cannot deliver** — the host
   preflight probes the instance's `sessionScope`, so a blank scope skips the check and a delivery whose
   fallback session is down is acked `200` and lost with no provider retry. Both the provisioning list

--- a/supabase-otp-hook/handler.test.ts
+++ b/supabase-otp-hook/handler.test.ts
@@ -154,6 +154,20 @@ test('debug mode logs the inbound delivery and send details without skipping the
   assert.ok(logs.some(l => l.message.includes('sending OTP')));
 });
 
+test('debug mode never writes the OTP or the destination number into a log', async () => {
+  // Debug is switched on precisely when a delivery is misbehaving, so its output is what gets pasted
+  // into a support thread or shipped to a log collector. A verification code is a live credential and
+  // the number beside it names its owner; neither belongs in a line written for diagnostics.
+  const { logs, deps } = makeDeps({ fallbackSessionId: 's', debug: true });
+  await handleSendSms(deps, makeReq({ user: { phone: '+15551234567' }, sms: { otp: '481932' } }, { sessionId: 'sess' }));
+
+  const written = JSON.stringify(logs);
+  assert.ok(!written.includes('481932'), `the OTP reached a log: ${written}`);
+  assert.ok(!written.includes('15551234567'), `the phone number reached a log: ${written}`);
+  // The diagnostic value has to survive: an operator still needs to see that a send was attempted.
+  assert.ok(logs.some((l) => l.message.includes('sending OTP')));
+});
+
 // ── pure helpers ────────────────────────────────────────────────────────────
 
 test('phoneToChatId strips non-digits and appends @c.us', () => {

--- a/supabase-otp-hook/handler.ts
+++ b/supabase-otp-hook/handler.ts
@@ -60,6 +60,16 @@ export function phoneToChatId(phone: unknown): string | undefined {
 }
 
 /** Substitute {appName} and {otp} into the template in a single pass. */
+/**
+ * A chat id reduced to what a diagnostic actually needs: enough to correlate two lines about the same
+ * chat, not enough to identify its owner. Debug output is what gets pasted into a support thread or
+ * shipped to a log collector, and a WhatsApp id is a phone number.
+ */
+export function maskChatId(chatId: string): string {
+  const [local, domain = 'c.us'] = chatId.split('@');
+  return local.length <= 4 ? `***@${domain}` : `***${local.slice(-4)}@${domain}`;
+}
+
 export function composeMessage(template: string, otp: string, appName: string): string {
   return template.replace(/\{appName\}|\{otp\}/g, token => (token === '{appName}' ? appName : otp));
 }
@@ -105,20 +115,21 @@ export async function handleSendSms(deps: HandlerDeps, req: WebhookRequest): Pro
       instanceId: req.instanceId,
       deliveryId: req.deliveryId,
       sessionId,
-      chatId: targetChatId,
+      chatId: maskChatId(targetChatId),
     });
   }
 
   const text = composeMessage(cfg.messageTemplate, otp, cfg.appName);
-  if (cfg.debug) deps.log('supabase-otp-hook: sending OTP', { debug: true, sessionId, chatId: targetChatId, text });
+  // Never the code itself: it is a live credential, and debug is on exactly when output is being shared.
+  if (cfg.debug) deps.log('supabase-otp-hook: sending OTP', { debug: true, sessionId, chatId: maskChatId(targetChatId), textLength: text.length });
 
   // Fire-and-forget: the worker dispatch is bounded to 5 s (INGRESS_DISPATCH_TIMEOUT_MS), so awaiting a
   // slow send risks a 504 → retry → DUPLICATE OTP. Background it; failures are logged, not retried.
   void deps.messages.sendText(sessionId, targetChatId, text).then(
-    () => { if (cfg.debug) deps.log('supabase-otp-hook: sendText ok', { debug: true, sessionId, chatId: targetChatId }); },
+    () => { if (cfg.debug) deps.log('supabase-otp-hook: sendText ok', { debug: true, sessionId, chatId: maskChatId(targetChatId) }); },
     (err: unknown) => {
       deps.log('supabase-otp-hook: sendText failed (background)', {
-        sessionId, chatId: targetChatId, error: err instanceof Error ? err.message : String(err),
+        sessionId, chatId: maskChatId(targetChatId), error: err instanceof Error ? err.message : String(err),
       });
     },
   );


### PR DESCRIPTION
Three defects, each in a guard that was meant to prevent exactly the thing it let through.

## supabase-otp-hook — debug logs carried the code and the number

Debug mode logged the composed message, which contains the verification code, and the destination chat id, which is a phone number, across three separate lines. Debug is switched on precisely when a delivery is misbehaving, so that output is what gets pasted into a support thread or shipped to a log collector — an OTP is a live credential, and the id beside it names its owner.

The send line now records the message length rather than the message, and chat ids are reduced to their last four digits: enough to correlate two lines about the same chat, not enough to identify anyone. The diagnostic still shows that a send was attempted, which is the point of debug mode.

## faq-bot — two ways past the rule-pattern safety analyser

The analyser rejects patterns prone to catastrophic backtracking before they reach `new RegExp`. Two of its assumptions were wrong, and both were reproduced:

- It reasoned that a small bounded repeat is bounded by its constant. True for a variable-width body, false for an unbounded one — `(a+){3}` expands to `a+a+a+`. Measured: 200 characters took 1.4 s, 1000 took over 6 s. Any repeat of an unbounded body is refused now, while `(ab?){2}` stays allowed, since that is the case the constant really does bound.
- It treated every group as breaking a run of adjacent unbounded quantifiers. A group that can match empty does not, so `.*(x?).*(x?).*` was `.*.*.*` in disguise; `\w*(a?)\w*(a?)\w*!` took 10.6 s on 300 characters. The run is now parked at the opening paren and resumed if the group turns out nullable. A group that must consume something still breaks it, so `.*(x).*(y).*` remains accepted.

Overlapping alternation is still not modelled, and the doc comment still says so.

## catalog — ingress declared without the permission

An ingress route becomes a public endpoint once the host provisions it, and the host refuses to load a plugin declaring one without `webhook:ingress`. That refusal lands at install, on the operator's gateway, after the release is tagged and published. The catalogue gate now checks it where the package is built.

## Verification

- 580 tests pass, typecheck clean, catalog up to date, all 10 plugins build and load.
- All three are test-first. The logging test failed showing the OTP and the full number in the log dump; the analyser tests failed on the patterns above; the catalogue gate was probed with a fixture manifest that declares a route and no permission, and refused it by name.
