### PR TITLE
fix: tighten the faq-bot responder and the catalogue's publish gates

### DIFF
--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -10,6 +10,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ### Fixed
 
+- **A message with no text no longer draws a fallback reply.** A sticker, image or voice note arrives
+  with an empty body, so no rule could match it and the fallback answered a picture with "I did not
+  understand" — and claimed the event, so a plugin that could handle media never saw it.
+- **A failed fallback send no longer silences the chat for a whole cooldown window.** The cooldown slot
+  is claimed before the send, so a send that threw spent the window on a reply that never arrived. The
+  slot is released on failure; a matched rule is retried on the next message the same way.
 - **Two rule patterns that could freeze the plugin are now rejected.** The safety analyser reasoned that
   a small bounded repeat is bounded by its constant, which holds for a variable-width body but not for an
   unbounded one: `(a+){3}` expands to `a+a+a+` and backtracks exponentially. It also treated any group as

--- a/faq-bot/index.test.ts
+++ b/faq-bot/index.test.ts
@@ -180,3 +180,45 @@ test('onMessage re-reads ctx.config per event (per-session config is not cached 
     data: { id: 'm1', chatId: 'c@x', body: 'hi', fromMe: false, isGroup: false } });
   assert.ok(warnings.some(w => /config invalid/.test(w)), 'corrupted post-enable config was re-read and warned');
 });
+
+test('a message with no text is left alone', async () => {
+  // A sticker, image or voice note arrives with an empty body — no rule matches, so the fallback fired
+  // and answered a picture with "sorry, I did not understand". Returning true also claims the event, so
+  // a later plugin that could handle media never saw it.
+  const replied: string[] = [];
+  const res = await runHook(
+    { rules: [{ mode: 'contains', pattern: 'hi', reply: 'hello' }], fallbackReply: 'tidak paham' },
+    '   ',
+    (t) => replied.push(t),
+  );
+  assert.deepEqual(replied, [], 'a message with no text must not draw a fallback');
+  assert.equal(res.continue, true, 'and must not be claimed');
+});
+
+test('a failed fallback send releases the cooldown slot instead of silencing the chat', async () => {
+  // The slot is claimed before the send. When the send throws, the window was spent anyway, so the chat
+  // stayed silent for the whole cooldown over a reply that never arrived.
+  const { default: FaqBot } = await import('./index.ts');
+  let failNext = true;
+  let delivered = 0;
+  let handler: ((h: unknown) => Promise<{ continue: boolean }>) | undefined;
+  const ctx = makeCtx({
+    config: { rules: JSON.stringify([{ mode: 'contains', pattern: 'hi', reply: 'hello' }]), fallbackReply: 'tidak paham', fallbackCooldownSec: 600 },
+    registerHook: (_e, h) => { handler = h as (h2: unknown) => Promise<{ continue: boolean }>; },
+    reply: async () => {
+      if (failNext) throw new Error('send failed');
+      delivered++;
+      return { messageId: 'x', timestamp: 0 };
+    },
+  });
+  await new FaqBot().onEnable(ctx as never);
+  const fire = (id: string) => handler!({
+    source: 'Engine', sessionId: 's1', timestamp: new Date(),
+    data: { id, chatId: 'c@x', body: 'apa kabar', fromMe: false, isGroup: false },
+  });
+
+  await fire('m1');           // send throws; the slot must not stay burnt
+  failNext = false;
+  await fire('m2');
+  assert.equal(delivered, 1, 'the next message must be able to retry the fallback');
+});

--- a/faq-bot/index.ts
+++ b/faq-bot/index.ts
@@ -75,7 +75,10 @@ export default class FaqBot implements IPlugin {
   private async onMessage(ctx: PluginContext, hook: HookContext): Promise<boolean> {
     if (hook.source !== 'Engine' || !hook.sessionId) return false;
     const m = (hook.data ?? {}) as Partial<IncomingMessage>;
-    if (m.fromMe || typeof m.body !== 'string' || !m.chatId || !m.id) return false;
+    // A sticker, image or voice note arrives with an empty body. No rule can match it, so the fallback
+    // would answer a picture with "I did not understand" and claim the event away from a plugin that
+    // could actually handle media. chat-flow guards the same way.
+    if (m.fromMe || typeof m.body !== 'string' || !m.body.trim() || !m.chatId || !m.id) return false;
 
     // Re-parse per event so a per-session config override (resolved by the host for this hook fire) is
     // honored — a snapshot cached at enable would ignore overrides set via the dashboard after enable.
@@ -100,7 +103,15 @@ export default class FaqBot implements IPlugin {
         const key = `${sessionId}:${m.chatId}`;
         const cooldownMs = Math.max(0, cfg.config.fallbackCooldownSec) * 1000;
         if (allowCooldown(this.fallbackAt, key, Date.now(), cooldownMs)) {
-          await ctx.messages.reply(sessionId, m.chatId, m.id, cfg.config.fallbackReply);
+          try {
+            await ctx.messages.reply(sessionId, m.chatId, m.id, cfg.config.fallbackReply);
+          } catch (err) {
+            // The slot is claimed before the send, so a failed send would otherwise silence the chat for
+            // a whole cooldown window over a reply that never arrived. Release it: a message that matched
+            // a rule is retried on the next message too, and this costs at most one send attempt each.
+            this.fallbackAt.delete(key);
+            throw err;
+          }
           return true;
         }
       }

--- a/scripts/catalog.mjs
+++ b/scripts/catalog.mjs
@@ -31,6 +31,10 @@ const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'it', 'ar', 'he', 'te', 'zh-CN', 'z
 //
 // A closed list makes adopting a genuinely new permission a deliberate one-line edit here — which is the
 // point. `storage:use` reached seven manifests without anything in this repo ever checking the name.
+// The GitHub owners whose Releases this catalogue is allowed to point at. A plugin may credit any
+// author; the ARTIFACT must come from a repo this project publishes.
+const RELEASE_OWNERS = new Set(['rmyndharis']);
+
 const HOST_PERMISSIONS = new Set([
   'messages:send',
   'engine:read',
@@ -43,6 +47,22 @@ const HOST_PERMISSIONS = new Set([
 
 // Manifest hygiene gates (hard failures) and soft warnings. Keep these aligned with PLUGIN-STANDARD.md.
 function validateManifest(id, manifest) {
+  // `id` here is the DIRECTORY name, and it is what every path in this repo is built from — the plugin
+  // folder, the zip name, the release tag. `manifest.id` is what the host installs under and what the
+  // catalogue publishes. If the two disagree, the download URL points at one plugin and the installed
+  // plugin calls itself another.
+  if (manifest.id !== id) {
+    throw new Error(`${id}: manifest.id is "${manifest.id}" — it must match the directory name`);
+  }
+  // The download URL is derived from `repository`, so a foreign host there would have the catalogue
+  // hand users an archive nobody in this repo built or checksummed.
+  const owner = /^https:\/\/github\.com\/([\w.-]+)\//.exec(manifest.repository ?? '');
+  if (!owner || !RELEASE_OWNERS.has(owner[1])) {
+    throw new Error(
+      `${id}: repository must be a github.com URL under ${[...RELEASE_OWNERS].join(' or ')} — ` +
+        `the catalogue builds its download URLs from it (got ${manifest.repository ?? 'nothing'})`,
+    );
+  }
   if (manifest.sessionScoped === undefined) {
     throw new Error(`${id}: manifest.json must declare "sessionScoped" explicitly (true or false)`);
   }


### PR DESCRIPTION
Four defects: two in how the FAQ responder decides to answer, two in what the catalogue is willing to publish.

## faq-bot — answering things it cannot answer

A sticker, image or voice note arrives with an empty body. No rule can match one, so the fallback replied to a picture with "I did not understand" — and returning true claimed the event, so a plugin that could actually handle media never saw it. The guard now requires text, which is how `chat-flow` already guards the same hook.

The fallback cooldown slot is claimed *before* the send. When the send threw, the window was spent on a reply that never arrived and the chat stayed silent for its full duration — by default ten minutes. The slot is now released on failure. A message matching a rule is retried on the next message anyway, so this costs at most one send attempt per message rather than one per window.

## catalog — two things nothing was checking

`manifest.id` was never compared to the directory name. Every path in this repo is built from the directory — the plugin folder, the zip, the release tag — while `manifest.id` is what the host installs under and what the catalogue publishes. A mismatch would have the download URL point at one plugin while the installed plugin called itself another.

`manifest.repository` had no constraint on its host, and the catalogue derives every download URL from it. Pointing it at a foreign repo would have the catalogue hand users an archive nobody here built or checksummed. The `author` field is deliberately unaffected — a plugin may credit anyone; the artifact has to come from a repo this project publishes.

## Verification

- 582 tests pass, typecheck clean, catalog up to date, all 10 plugins build and load.
- Both catalogue gates were probed with fixture manifests: a mismatched id and a foreign repository host are each refused by name, and a correct manifest draws no complaint.
- Both faq-bot fixes are test-first; the cooldown test drives a failing send and then a working one, and would pass trivially without the fix only if the slot were never claimed.
