### PR TITLE
test(catalog): hold manifest.hooks to the events the code registers

### DIFF
--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -113,6 +113,7 @@ curl -X POST "$OPENWA/api/plugins/chatwoot-adapter/enable" \
 | `inboxId` | number | yes | The API-channel inbox id this adapter posts into and relays replies from. |
 | `relayGroups` | boolean | no (default `true`) | Relay group chats (one synthetic contact per group, sender-prefixed). |
 | `relayMedia` | boolean | no (default `true`) | Upload inbound media to Chatwoot as attachments. |
+| `relayOwnMessages` | boolean | no (default `true`) | Mirror messages you send from your own phone into Chatwoot, so an agent sees both sides of the conversation. Turn it off to relay only what contacts send you. |
 | `backfillLimit` | number | no (default `0`) | When a chat first opens in Chatwoot, import this many recent messages (both directions) so agents see prior context. Attachments are imported only at 25 or below — above that the import would exceed the host's 30-second budget and fail, so older media arrives as a placeholder line instead. `0` disables it; clamped to 100 host-side. Needs OpenWA 0.8.6+ and the whatsapp-web.js engine (Baileys has no history support). |
 | `backfillAllOnce` | boolean | no (default `false`) | Also run a one-time sweep importing every existing chat's history on setup. Needs `backfillLimit` > 0. Runs once per session. |
 

--- a/scripts/manifest-hooks.test.mjs
+++ b/scripts/manifest-hooks.test.mjs
@@ -1,0 +1,63 @@
+// `manifest.hooks` tells an operator (and the dashboard) which events a plugin binds. Nothing compared
+// it to the events the code actually registers, so it could drift in either direction: a hook added in
+// code and not declared, or a declared hook the plugin no longer listens for.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pluginDirs = readdirSync(ROOT, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && existsSync(join(ROOT, d.name, 'manifest.json')))
+  .map((d) => d.name);
+
+function sourceFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'dist' || entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) sourceFiles(path, out);
+    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(path);
+  }
+  return out;
+}
+
+// The event a `registerHook` call binds. Both quote styles are in use — matching only one of them
+// silently finds nothing, which reads exactly like a plugin that registers no hooks.
+function registeredEvents(dir) {
+  const found = new Set();
+  for (const file of sourceFiles(join(ROOT, dir))) {
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(/registerHook\(\s*['"]([\w:]+)['"]/g)) found.add(m[1]);
+    // gsheets-logger registers from a list rather than inline, so also take the typed event constants.
+    for (const m of src.matchAll(/HookEvent\[\]\s*=\s*\[([^\]]*)\]/g)) {
+      for (const e of m[1].matchAll(/['"]([\w:]+)['"]/g)) found.add(e[1]);
+    }
+  }
+  return [...found].sort();
+}
+
+test('every plugin registers hooks and declares them', () => {
+  // The precondition and the comparison in one: a plugin with neither is a plugin whose sources this
+  // check failed to read, which would otherwise look like agreement.
+  const withHooks = pluginDirs.filter((d) => registeredEvents(d).length > 0);
+  assert.ok(withHooks.length >= pluginDirs.length - 1, `only ${withHooks.length} of ${pluginDirs.length} plugins appear to register a hook — the source scan is probably wrong`);
+
+  const drift = [];
+  for (const dir of pluginDirs) {
+    const declared = [...(JSON.parse(readFileSync(join(ROOT, dir, 'manifest.json'), 'utf8')).hooks ?? [])].sort();
+    const registered = registeredEvents(dir);
+    if (JSON.stringify(declared) !== JSON.stringify(registered)) {
+      drift.push(`${dir}: manifest declares [${declared}] but the code registers [${registered}]`);
+    }
+  }
+  assert.deepEqual(drift, []);
+});
+
+test('a plugin directory is discoverable and readable', () => {
+  assert.ok(pluginDirs.length > 0, `no plugin directories under ${ROOT}`);
+  for (const dir of pluginDirs) {
+    assert.ok(statSync(join(ROOT, dir, 'manifest.json')).size > 0, `${dir}: empty manifest`);
+  }
+});


### PR DESCRIPTION
`manifest.hooks` tells an operator — and the dashboard — which events a plugin binds. Nothing compared it to the events the code actually registers, so it could drift in either direction: a hook added in code and never declared, or a declared hook the plugin no longer listens for.

The new check reads every non-test source file per plugin and compares the two sets.

One detail worth recording: it matches **both** quote styles. An earlier pass of this comparison matched only single quotes and reported two plugins as registering nothing at all — `group-translate` and `voice-transcription` write `registerHook("message:received", …)`. A pattern that silently finds nothing is indistinguishable from a plugin with no hooks, so the test also asserts that nearly every plugin appears to register something; a scan that stops working fails loudly rather than agreeing with itself.

Proven to bite: adding `message:ack` to one manifest produces `manifest declares [message:ack,message:received,message:sent] but the code registers [message:received,message:sent]`.

Separately, this adds the `relayOwnMessages` row to the chatwoot-adapter configuration table. It defaults to `true` and mirrors your own outgoing messages into Chatwoot — worth knowing before installing. It was described in prose further down, but absent from the table an operator actually reads.

## Verification

- 584 tests pass, catalog up to date.
