### PR TITLE
fix(gsheets-logger): park undelivered rows across a spreadsheet rotation

### DIFF
--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -10,6 +10,10 @@ The version here always matches `manifest.json`'s `version`.
 
 ### Fixed
 
+- **Undelivered rows no longer follow a spreadsheet rotation.** `onConfigChange` drains before swapping
+  the client, but a drain that cannot reach Sheets leaves every row in place — and those rows carry
+  message content captured under the previous spreadsheet and credentials. They are now parked under
+  their own storage key, reported once, and never sent to the new target.
 - **The buffer is now bounded by size, not only by row count.** The 5,000-row cap allowed cells of up
   to 50,000 characters across 14 columns, so the row count alone permitted a buffer far larger than the
   worker heap — reachable whenever Sheets is unreachable and the retain-on-failure path holds rows.

--- a/gsheets-logger/index.test.ts
+++ b/gsheets-logger/index.test.ts
@@ -233,3 +233,36 @@ test('restoring a buffer reports what it dropped instead of losing rows silently
   assert.match(warns[0], /2 malformed/);
   assert.match(warns[0], /\d+ oldest/);
 });
+
+test('rows buffered for the old spreadsheet never cross into the new one', async () => {
+  // onConfigChange drains before swapping so rows land in the sheet they belong to. But flush() swallows
+  // its own failure, so with Sheets unreachable the drain leaves every row in place — and the next flush
+  // sends message content captured under one spreadsheet and credential to a different one.
+  const logger = new GSheetsLogger();
+  const stored: Record<string, unknown> = {};
+  const warns: string[] = [];
+  const harness = logger as unknown as { client: unknown; ctx: unknown; buffer: string[][] };
+  harness.client = { appendRows: async (): Promise<void> => { throw new Error('sheets unreachable'); } };
+  harness.ctx = {
+    storage: { get: async (k: string) => stored[k] ?? null, set: async (k: string, v: unknown) => void (stored[k] = v) },
+    logger: { warn: (m: string): void => void warns.push(m), error: (): void => {}, log: (): void => {} },
+  };
+  harness.buffer = [['old-row-1'], ['old-row-2']];
+
+  await logger.onConfigChange(
+    {
+      config: { spreadsheetId: 'NEW-SHEET', serviceAccountJson: validSa },
+      net: { fetch: async () => ({ ok: true, status: 200, body: '{}' }) },
+      storage: { get: async (k: string) => stored[k] ?? null, set: async (k: string, v: unknown) => void (stored[k] = v) },
+      logger: { warn: (m: string): void => void warns.push(m), error: (): void => {}, log: (): void => {} },
+    } as never,
+    {},
+  );
+  await logger.onUnload();
+
+  assert.deepEqual(harness.buffer, [], 'undelivered rows must not remain queued against the new sheet');
+  assert.ok(warns.some((w) => /2 row/.test(w)), `the operator must be told, got ${JSON.stringify(warns)}`);
+  const parked = Object.entries(stored).find(([k]) => k.includes('undelivered'));
+  assert.ok(parked, `the rows must be kept somewhere, stored keys: ${Object.keys(stored)}`);
+  assert.deepEqual(parked?.[1], [['old-row-1'], ['old-row-2']]);
+});

--- a/gsheets-logger/index.ts
+++ b/gsheets-logger/index.ts
@@ -4,6 +4,10 @@ import { buildRow } from './row.ts';
 
 const LOGGED_EVENTS: HookEvent[] = ['message:received', 'message:sent', 'message:failed', 'message:ack'];
 const BUFFER_KEY = 'buffer';
+// Rows that could not be delivered to the spreadsheet they were captured for. Kept out of the live
+// buffer so they are never sent to a different target, and out of the way of the quota by sharing the
+// same caps as the buffer itself.
+const UNDELIVERED_KEY = 'buffer:undelivered';
 const MAX_BUFFER = 5000;
 // The row cap alone does not bound memory: row.ts allows 50,000 characters per cell across 14 columns,
 // so 5,000 rows can reach hundreds of millions of characters against a 256 MB worker heap — and the
@@ -143,6 +147,25 @@ export default class GSheetsLogger implements IPlugin {
     // Drain to the current (old) client before swapping, so rows buffered before a spreadsheet/credential
     // rotation land in the sheet they belong to — not the new one. flush() is guarded and a no-op when empty.
     await this.flush();
+    // flush() swallows its own failure, so a drain that could not reach Sheets leaves every row in place.
+    // Those rows carry message content captured under the previous spreadsheet and credentials; sending
+    // them to the new target would move it across exactly the boundary the operator just changed. Park
+    // them under their own key instead — kept, but never delivered anywhere they do not belong.
+    if (this.buffer.length > 0) {
+      const undelivered = this.buffer.splice(0, this.buffer.length);
+      try {
+        const existing = await this.ctx?.storage.get<string[][]>(UNDELIVERED_KEY);
+        const kept = [...(Array.isArray(existing) ? existing : []), ...undelivered];
+        capBuffer(kept, MAX_BUFFER, MAX_BUFFER_CHARS);
+        await this.ctx?.storage.set(UNDELIVERED_KEY, kept);
+        ctx.logger.warn(
+          `gsheets-logger: ${undelivered.length} row(s) were still undelivered at a config change; ` +
+            `parked under "${UNDELIVERED_KEY}" rather than sent to the new sheet`,
+        );
+      } catch (err) {
+        ctx.logger.error(`gsheets-logger: ${undelivered.length} undelivered row(s) could not be parked`, err);
+      }
+    }
     this.ctx = ctx;
     const { config, sa } = parseConfig(ctx.config);
     this.client = new SheetsClient(ctx.net.fetch.bind(ctx.net), sa, config.spreadsheetId, config.sheetTab);

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+### Changed
+
+- **`chatDelivery: reply` now says what it does in a group.** The option posts a quote-reply to the
+  sender, which in a group is visible to every member — the transcript of a voice note read out to the
+  whole chat. The behaviour is unchanged and still defaults to `off`; the config description and the
+  README table now state the group consequence before an operator turns it on.
+
 ## [1.2.3] — 2026-08-12
 
 ### Changed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -129,7 +129,7 @@ curl -X POST http://localhost:2785/api/plugins/voice-transcription/enable \
 | `deliveryWebhookUrl` | cond. | — | Endpoint receiving the `message.transcription` event. Must be https, and is then allowed automatically. Optional if you only use `chatDelivery`. |
 | `deliverySecret` | no | — | Optional. HMAC-SHA256 signs the body in `X-OpenWA-Signature: sha256=<hex>` (same as core webhooks). Stored redacted. |
 | `deliveryTimeoutMs` | no | `5000` | Delivery POST timeout. |
-| `chatDelivery` | no | `off` | Also post the transcript into WhatsApp: `off` (webhook only) · `self` (note to your own number) · `reply` (quote-reply to the sender — visible to them). |
+| `chatDelivery` | no | `off` | Also post the transcript into WhatsApp: `off` (webhook only) · `self` (note to your own number) · `reply` (quote-reply to the sender — visible to them). **In a group, `reply` posts to the whole group**, so every member reads the contents of the voice note. |
 
 ## Compatibility
 

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.2.3",
   "type": "extension",
   "main": "dist/index.js",
-  "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
+  "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook \u2014 so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
   "author": "Yudhi Armyndharis <yudhi@rmyndharis.com>",
   "license": "MIT",
   "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
@@ -37,7 +37,10 @@
       "api.groq.com:443",
       "api.openai.com:443"
     ],
-    "allowConfigHosts": ["sttBaseUrl", "deliveryWebhookUrl"]
+    "allowConfigHosts": [
+      "sttBaseUrl",
+      "deliveryWebhookUrl"
+    ]
   },
   "sessionScoped": true,
   "sessions": [
@@ -53,7 +56,7 @@
         "type": "string",
         "title": "STT base URL",
         "required": true,
-        "description": "Base URL of an OpenAI-compatible /v1/audio/transcriptions server — e.g. http://localhost:8000 (Speaches/faster-whisper) or https://api.groq.com/openai. An https host you set here is allowed automatically; a localhost/127.0.0.1 target is already allowed but ALSO requires SSRF_ALLOWED_HOSTS on the OpenWA host (use a literal 127.0.0.1)."
+        "description": "Base URL of an OpenAI-compatible /v1/audio/transcriptions server \u2014 e.g. http://localhost:8000 (Speaches/faster-whisper) or https://api.groq.com/openai. An https host you set here is allowed automatically; a localhost/127.0.0.1 target is already allowed but ALSO requires SSRF_ALLOWED_HOSTS on the OpenWA host (use a literal 127.0.0.1)."
       },
       "sttApiKey": {
         "type": "string",
@@ -85,7 +88,7 @@
         "default": 20000,
         "min": 1000,
         "max": 25000,
-        "description": "Per-request STT timeout. Runs off the message-delivery path, so it is not bound by the 5s hook budget — but it races the host's 30000ms per-capability ceiling, so keep it below that."
+        "description": "Per-request STT timeout. Runs off the message-delivery path, so it is not bound by the 5s hook budget \u2014 but it races the host's 30000ms per-capability ceiling, so keep it below that."
       },
       "enabledMessageTypes": {
         "type": "array",
@@ -113,7 +116,7 @@
       "deliveryWebhookUrl": {
         "type": "string",
         "title": "Delivery webhook URL",
-        "description": "Your endpoint that receives the message.transcription event (the bot/AI integration channel). Must be https — an https host you set here is allowed automatically. Optional if you only use in-chat delivery."
+        "description": "Your endpoint that receives the message.transcription event (the bot/AI integration channel). Must be https \u2014 an https host you set here is allowed automatically. Optional if you only use in-chat delivery."
       },
       "deliverySecret": {
         "type": "string",
@@ -137,29 +140,370 @@
           "reply"
         ],
         "default": "off",
-        "description": "Also post the transcript into WhatsApp: off (webhook only), self (a note to your own number), or reply (quote-reply to the sender — visible to them). Default off."
+        "description": "Also post the transcript into WhatsApp: off (webhook only), self (a note to your own number), or reply (quote-reply to the sender). In a GROUP, reply posts the transcript to the whole group \u2014 every member sees the contents of the voice note. Default off."
       }
     }
   },
   "i18n": {
     "es": {
-      "name": "Transcripción de Notas de Voz",
+      "name": "Transcripci\u00f3n de Notas de Voz",
       "description": "Transcribe las notas de voz entrantes de WhatsApp a texto mediante un backend de voz a texto compatible con OpenAI (Speaches/faster-whisper autoalojado o Groq/OpenAI) y entrega un evento message.transcription a tu webhook, para que los bots y la IA puedan leer y responder al audio. Fuera de la ruta de entrega de mensajes; desactivado hasta que se habilite.",
-      "config": { "sttBaseUrl": { "title": "URL base de STT" }, "sttApiKey": { "title": "Clave API de STT" }, "model": { "title": "Modelo" }, "language": { "title": "Sugerencia de idioma" }, "provider": { "title": "Etiqueta del proveedor" }, "timeoutMs": { "title": "Tiempo de espera de STT (ms)" }, "enabledMessageTypes": { "title": "Tipos de mensaje a transcribir" }, "maxSizeBytes": { "title": "Tamaño máximo de audio (bytes)" }, "maxPerHour": { "title": "Transcripciones máximas / hora / sesión" }, "deliveryWebhookUrl": { "title": "URL del webhook de entrega" }, "deliverySecret": { "title": "Secreto de entrega" }, "deliveryTimeoutMs": { "title": "Tiempo de espera de entrega (ms)" }, "chatDelivery": { "title": "Entrega en el chat" } }
+      "config": {
+        "sttBaseUrl": {
+          "title": "URL base de STT"
+        },
+        "sttApiKey": {
+          "title": "Clave API de STT"
+        },
+        "model": {
+          "title": "Modelo"
+        },
+        "language": {
+          "title": "Sugerencia de idioma"
+        },
+        "provider": {
+          "title": "Etiqueta del proveedor"
+        },
+        "timeoutMs": {
+          "title": "Tiempo de espera de STT (ms)"
+        },
+        "enabledMessageTypes": {
+          "title": "Tipos de mensaje a transcribir"
+        },
+        "maxSizeBytes": {
+          "title": "Tama\u00f1o m\u00e1ximo de audio (bytes)"
+        },
+        "maxPerHour": {
+          "title": "Transcripciones m\u00e1ximas / hora / sesi\u00f3n"
+        },
+        "deliveryWebhookUrl": {
+          "title": "URL del webhook de entrega"
+        },
+        "deliverySecret": {
+          "title": "Secreto de entrega"
+        },
+        "deliveryTimeoutMs": {
+          "title": "Tiempo de espera de entrega (ms)"
+        },
+        "chatDelivery": {
+          "title": "Entrega en el chat"
+        }
+      }
     },
-    "fr": { "name": "Transcription de notes vocales", "description": "Transcrit les notes vocales WhatsApp entrantes en texte via un backend de reconnaissance vocale compatible OpenAI (Speaches/faster-whisper auto-hébergé ou Groq/OpenAI hébergé) et envoie un événement `message.transcription` à votre webhook — pour que les bots et l'IA puissent lire et répondre à l'audio. Hors du chemin de livraison des messages ; désactivé jusqu'à activation.",
-      "config": { "sttBaseUrl": { "title": "URL de base STT" }, "sttApiKey": { "title": "Clé API STT" }, "model": { "title": "Modèle" }, "language": { "title": "Indication de langue" }, "provider": { "title": "Étiquette du fournisseur" }, "timeoutMs": { "title": "Délai d'attente STT (ms)" }, "enabledMessageTypes": { "title": "Types de messages à transcrire" }, "maxSizeBytes": { "title": "Taille audio max (octets)" }, "maxPerHour": { "title": "Transcriptions max / heure / session" }, "deliveryWebhookUrl": { "title": "URL du webhook de livraison" }, "deliverySecret": { "title": "Secret de livraison" }, "deliveryTimeoutMs": { "title": "Délai d'attente de livraison (ms)" }, "chatDelivery": { "title": "Livraison dans le chat" } } },
-    "it": { "name": "Trascrizione note vocali", "description": "Trascrive le note vocali WhatsApp in arrivo in testo tramite un backend speech-to-text compatibile con OpenAI (Speaches/faster-whisper self-hosted o Groq/OpenAI in hosting) e consegna un evento `message.transcription` al tuo webhook — così bot e IA possono leggere e rispondere all'audio. Fuori dal percorso di consegna dei messaggi; disabilitato finché non viene abilitato.",
-      "config": { "sttBaseUrl": { "title": "URL base STT" }, "sttApiKey": { "title": "Chiave API STT" }, "model": { "title": "Modello" }, "language": { "title": "Suggerimento lingua" }, "provider": { "title": "Etichetta del provider" }, "timeoutMs": { "title": "Timeout STT (ms)" }, "enabledMessageTypes": { "title": "Tipi di messaggio da trascrivere" }, "maxSizeBytes": { "title": "Dimensione max audio (byte)" }, "maxPerHour": { "title": "Trascrizioni max / ora / sessione" }, "deliveryWebhookUrl": { "title": "URL del webhook di consegna" }, "deliverySecret": { "title": "Segreto di consegna" }, "deliveryTimeoutMs": { "title": "Timeout di consegna (ms)" }, "chatDelivery": { "title": "Consegna in chat" } } },
-    "ar": { "name": "نسخ الملاحظات الصوتية", "description": "ينسخ الملاحظات الصوتية الواردة في WhatsApp إلى نص عبر خلفية تحويل كلام إلى نص متوافقة مع OpenAI (Speaches/faster-whisper ذاتية الاستضافة أو Groq/OpenAI المستضافة) ويسلّم حدث `message.transcription` إلى webhook الخاص بك — حتى تتمكن البوتات والذكاء الاصطناعي من قراءة الصوت والرد عليه. خارج مسار تسليم الرسائل؛ معطّل حتى يتم تفعيله.",
-      "config": { "sttBaseUrl": { "title": "الرابط الأساسي لـ STT" }, "sttApiKey": { "title": "مفتاح API لـ STT" }, "model": { "title": "النموذج" }, "language": { "title": "تلميح اللغة" }, "provider": { "title": "تسمية المزوّد" }, "timeoutMs": { "title": "مهلة STT (ميلي ثانية)" }, "enabledMessageTypes": { "title": "أنواع الرسائل المراد نسخها" }, "maxSizeBytes": { "title": "الحد الأقصى لحجم الصوت (بايت)" }, "maxPerHour": { "title": "أقصى عدد نسخ / ساعة / جلسة" }, "deliveryWebhookUrl": { "title": "رابط webhook للتسليم" }, "deliverySecret": { "title": "سرّ التسليم" }, "deliveryTimeoutMs": { "title": "مهلة التسليم (ميلي ثانية)" }, "chatDelivery": { "title": "التسليم داخل المحادثة" } } },
-    "he": { "name": "תמלול הודעות קוליות", "description": "מתמלל הודעות קוליות נכנסות ב-WhatsApp לטקסט באמצעות שרת דיבור-לטקסט תואם OpenAI (Speaches/faster-whisper באירוח עצמי או Groq/OpenAI באירוח) ומעביר אירוע `message.transcription` ל-webhook שלך — כך שבוטים ו-AI יכולים לקרוא ולהשיב לאודיו. מחוץ לנתיב מסירת ההודעות; מושבת עד שמופעל.",
-      "config": { "sttBaseUrl": { "title": "כתובת בסיס של STT" }, "sttApiKey": { "title": "מפתח API של STT" }, "model": { "title": "מודל" }, "language": { "title": "רמז שפה" }, "provider": { "title": "תווית ספק" }, "timeoutMs": { "title": "פסק זמן STT (ms)" }, "enabledMessageTypes": { "title": "סוגי הודעות לתמלול" }, "maxSizeBytes": { "title": "גודל אודיו מרבי (בייטים)" }, "maxPerHour": { "title": "מקסימום תמלולים / שעה / סשן" }, "deliveryWebhookUrl": { "title": "כתובת webhook למסירה" }, "deliverySecret": { "title": "סוד מסירה" }, "deliveryTimeoutMs": { "title": "פסק זמן מסירה (ms)" }, "chatDelivery": { "title": "מסירה בתוך הצ'אט" } } },
-    "te": { "name": "వాయిస్ నోట్ ట్రాన్స్‌క్రిప్షన్", "description": "ఇన్‌బౌండ్ WhatsApp వాయిస్ నోట్‌లను OpenAI-అనుకూల స్పీచ్-టు-టెక్స్ట్ బ్యాక్‌ఎండ్ (స్వీయ-హోస్ట్ చేసిన Speaches/faster-whisper లేదా హోస్ట్ చేసిన Groq/OpenAI) ద్వారా టెక్స్ట్‌గా మారుస్తుంది మరియు `message.transcription` ఈవెంట్‌ను మీ webhook కు డెలివర్ చేస్తుంది — తద్వారా బాట్‌లు మరియు AI ఆడియోను చదవగలవు మరియు స్పందించగలవు. సందేశ-డెలివరీ మార్గం నుండి బయట; ప్రారంభించే వరకు నిలిపివేయబడింది.",
-      "config": { "sttBaseUrl": { "title": "STT బేస్ URL" }, "sttApiKey": { "title": "STT API కీ" }, "model": { "title": "మోడల్" }, "language": { "title": "భాషా సూచన" }, "provider": { "title": "ప్రొవైడర్ లేబుల్" }, "timeoutMs": { "title": "STT టైమ్‌అవుట్ (ms)" }, "enabledMessageTypes": { "title": "ట్రాన్స్‌క్రైబ్ చేయాల్సిన సందేశ రకాలు" }, "maxSizeBytes": { "title": "గరిష్ట ఆడియో పరిమాణం (బైట్లు)" }, "maxPerHour": { "title": "గరిష్ట ట్రాన్స్‌క్రిప్షన్‌లు / గంట / సెషన్" }, "deliveryWebhookUrl": { "title": "డెలివరీ webhook URL" }, "deliverySecret": { "title": "డెలివరీ రహస్యం" }, "deliveryTimeoutMs": { "title": "డెలివరీ టైమ్‌అవుట్ (ms)" }, "chatDelivery": { "title": "చాట్‌లో డెలివరీ" } } },
-    "zh-CN": { "name": "语音消息转写", "description": "通过兼容 OpenAI 的语音转文字后端（自托管 Speaches/faster-whisper 或托管的 Groq/OpenAI）将传入的 WhatsApp 语音消息转写为文本，并向你的 webhook 投递 `message.transcription` 事件——让机器人和 AI 能够读取并回复语音。不在消息投递路径上；启用前保持禁用。",
-      "config": { "sttBaseUrl": { "title": "STT 基础 URL" }, "sttApiKey": { "title": "STT API 密钥" }, "model": { "title": "模型" }, "language": { "title": "语言提示" }, "provider": { "title": "提供商标签" }, "timeoutMs": { "title": "STT 超时（毫秒）" }, "enabledMessageTypes": { "title": "要转写的消息类型" }, "maxSizeBytes": { "title": "最大音频大小（字节）" }, "maxPerHour": { "title": "每小时每会话最大转写数" }, "deliveryWebhookUrl": { "title": "投递 webhook URL" }, "deliverySecret": { "title": "投递密钥" }, "deliveryTimeoutMs": { "title": "投递超时（毫秒）" }, "chatDelivery": { "title": "聊天内投递" } } },
-    "zh-HK": { "name": "語音訊息轉寫", "description": "透過兼容 OpenAI 的語音轉文字後端（自託管 Speaches/faster-whisper 或託管的 Groq/OpenAI）將傳入的 WhatsApp 語音訊息轉寫為文字，並向你的 webhook 投遞 `message.transcription` 事件——讓機器人及 AI 能夠讀取並回覆語音。不在訊息投遞路徑上；啟用前保持停用。",
-      "config": { "sttBaseUrl": { "title": "STT 基礎 URL" }, "sttApiKey": { "title": "STT API 金鑰" }, "model": { "title": "模型" }, "language": { "title": "語言提示" }, "provider": { "title": "提供者標籤" }, "timeoutMs": { "title": "STT 逾時（毫秒）" }, "enabledMessageTypes": { "title": "要轉寫的訊息類型" }, "maxSizeBytes": { "title": "最大音訊大小（位元組）" }, "maxPerHour": { "title": "每小時每工作階段最大轉寫數" }, "deliveryWebhookUrl": { "title": "投遞 webhook URL" }, "deliverySecret": { "title": "投遞密鑰" }, "deliveryTimeoutMs": { "title": "投遞逾時（毫秒）" }, "chatDelivery": { "title": "對話內投遞" } } }
+    "fr": {
+      "name": "Transcription de notes vocales",
+      "description": "Transcrit les notes vocales WhatsApp entrantes en texte via un backend de reconnaissance vocale compatible OpenAI (Speaches/faster-whisper auto-h\u00e9berg\u00e9 ou Groq/OpenAI h\u00e9berg\u00e9) et envoie un \u00e9v\u00e9nement `message.transcription` \u00e0 votre webhook \u2014 pour que les bots et l'IA puissent lire et r\u00e9pondre \u00e0 l'audio. Hors du chemin de livraison des messages ; d\u00e9sactiv\u00e9 jusqu'\u00e0 activation.",
+      "config": {
+        "sttBaseUrl": {
+          "title": "URL de base STT"
+        },
+        "sttApiKey": {
+          "title": "Cl\u00e9 API STT"
+        },
+        "model": {
+          "title": "Mod\u00e8le"
+        },
+        "language": {
+          "title": "Indication de langue"
+        },
+        "provider": {
+          "title": "\u00c9tiquette du fournisseur"
+        },
+        "timeoutMs": {
+          "title": "D\u00e9lai d'attente STT (ms)"
+        },
+        "enabledMessageTypes": {
+          "title": "Types de messages \u00e0 transcrire"
+        },
+        "maxSizeBytes": {
+          "title": "Taille audio max (octets)"
+        },
+        "maxPerHour": {
+          "title": "Transcriptions max / heure / session"
+        },
+        "deliveryWebhookUrl": {
+          "title": "URL du webhook de livraison"
+        },
+        "deliverySecret": {
+          "title": "Secret de livraison"
+        },
+        "deliveryTimeoutMs": {
+          "title": "D\u00e9lai d'attente de livraison (ms)"
+        },
+        "chatDelivery": {
+          "title": "Livraison dans le chat"
+        }
+      }
+    },
+    "it": {
+      "name": "Trascrizione note vocali",
+      "description": "Trascrive le note vocali WhatsApp in arrivo in testo tramite un backend speech-to-text compatibile con OpenAI (Speaches/faster-whisper self-hosted o Groq/OpenAI in hosting) e consegna un evento `message.transcription` al tuo webhook \u2014 cos\u00ec bot e IA possono leggere e rispondere all'audio. Fuori dal percorso di consegna dei messaggi; disabilitato finch\u00e9 non viene abilitato.",
+      "config": {
+        "sttBaseUrl": {
+          "title": "URL base STT"
+        },
+        "sttApiKey": {
+          "title": "Chiave API STT"
+        },
+        "model": {
+          "title": "Modello"
+        },
+        "language": {
+          "title": "Suggerimento lingua"
+        },
+        "provider": {
+          "title": "Etichetta del provider"
+        },
+        "timeoutMs": {
+          "title": "Timeout STT (ms)"
+        },
+        "enabledMessageTypes": {
+          "title": "Tipi di messaggio da trascrivere"
+        },
+        "maxSizeBytes": {
+          "title": "Dimensione max audio (byte)"
+        },
+        "maxPerHour": {
+          "title": "Trascrizioni max / ora / sessione"
+        },
+        "deliveryWebhookUrl": {
+          "title": "URL del webhook di consegna"
+        },
+        "deliverySecret": {
+          "title": "Segreto di consegna"
+        },
+        "deliveryTimeoutMs": {
+          "title": "Timeout di consegna (ms)"
+        },
+        "chatDelivery": {
+          "title": "Consegna in chat"
+        }
+      }
+    },
+    "ar": {
+      "name": "\u0646\u0633\u062e \u0627\u0644\u0645\u0644\u0627\u062d\u0638\u0627\u062a \u0627\u0644\u0635\u0648\u062a\u064a\u0629",
+      "description": "\u064a\u0646\u0633\u062e \u0627\u0644\u0645\u0644\u0627\u062d\u0638\u0627\u062a \u0627\u0644\u0635\u0648\u062a\u064a\u0629 \u0627\u0644\u0648\u0627\u0631\u062f\u0629 \u0641\u064a WhatsApp \u0625\u0644\u0649 \u0646\u0635 \u0639\u0628\u0631 \u062e\u0644\u0641\u064a\u0629 \u062a\u062d\u0648\u064a\u0644 \u0643\u0644\u0627\u0645 \u0625\u0644\u0649 \u0646\u0635 \u0645\u062a\u0648\u0627\u0641\u0642\u0629 \u0645\u0639 OpenAI (Speaches/faster-whisper \u0630\u0627\u062a\u064a\u0629 \u0627\u0644\u0627\u0633\u062a\u0636\u0627\u0641\u0629 \u0623\u0648 Groq/OpenAI \u0627\u0644\u0645\u0633\u062a\u0636\u0627\u0641\u0629) \u0648\u064a\u0633\u0644\u0651\u0645 \u062d\u062f\u062b `message.transcription` \u0625\u0644\u0649 webhook \u0627\u0644\u062e\u0627\u0635 \u0628\u0643 \u2014 \u062d\u062a\u0649 \u062a\u062a\u0645\u0643\u0646 \u0627\u0644\u0628\u0648\u062a\u0627\u062a \u0648\u0627\u0644\u0630\u0643\u0627\u0621 \u0627\u0644\u0627\u0635\u0637\u0646\u0627\u0639\u064a \u0645\u0646 \u0642\u0631\u0627\u0621\u0629 \u0627\u0644\u0635\u0648\u062a \u0648\u0627\u0644\u0631\u062f \u0639\u0644\u064a\u0647. \u062e\u0627\u0631\u062c \u0645\u0633\u0627\u0631 \u062a\u0633\u0644\u064a\u0645 \u0627\u0644\u0631\u0633\u0627\u0626\u0644\u061b \u0645\u0639\u0637\u0651\u0644 \u062d\u062a\u0649 \u064a\u062a\u0645 \u062a\u0641\u0639\u064a\u0644\u0647.",
+      "config": {
+        "sttBaseUrl": {
+          "title": "\u0627\u0644\u0631\u0627\u0628\u0637 \u0627\u0644\u0623\u0633\u0627\u0633\u064a \u0644\u0640 STT"
+        },
+        "sttApiKey": {
+          "title": "\u0645\u0641\u062a\u0627\u062d API \u0644\u0640 STT"
+        },
+        "model": {
+          "title": "\u0627\u0644\u0646\u0645\u0648\u0630\u062c"
+        },
+        "language": {
+          "title": "\u062a\u0644\u0645\u064a\u062d \u0627\u0644\u0644\u063a\u0629"
+        },
+        "provider": {
+          "title": "\u062a\u0633\u0645\u064a\u0629 \u0627\u0644\u0645\u0632\u0648\u0651\u062f"
+        },
+        "timeoutMs": {
+          "title": "\u0645\u0647\u0644\u0629 STT (\u0645\u064a\u0644\u064a \u062b\u0627\u0646\u064a\u0629)"
+        },
+        "enabledMessageTypes": {
+          "title": "\u0623\u0646\u0648\u0627\u0639 \u0627\u0644\u0631\u0633\u0627\u0626\u0644 \u0627\u0644\u0645\u0631\u0627\u062f \u0646\u0633\u062e\u0647\u0627"
+        },
+        "maxSizeBytes": {
+          "title": "\u0627\u0644\u062d\u062f \u0627\u0644\u0623\u0642\u0635\u0649 \u0644\u062d\u062c\u0645 \u0627\u0644\u0635\u0648\u062a (\u0628\u0627\u064a\u062a)"
+        },
+        "maxPerHour": {
+          "title": "\u0623\u0642\u0635\u0649 \u0639\u062f\u062f \u0646\u0633\u062e / \u0633\u0627\u0639\u0629 / \u062c\u0644\u0633\u0629"
+        },
+        "deliveryWebhookUrl": {
+          "title": "\u0631\u0627\u0628\u0637 webhook \u0644\u0644\u062a\u0633\u0644\u064a\u0645"
+        },
+        "deliverySecret": {
+          "title": "\u0633\u0631\u0651 \u0627\u0644\u062a\u0633\u0644\u064a\u0645"
+        },
+        "deliveryTimeoutMs": {
+          "title": "\u0645\u0647\u0644\u0629 \u0627\u0644\u062a\u0633\u0644\u064a\u0645 (\u0645\u064a\u0644\u064a \u062b\u0627\u0646\u064a\u0629)"
+        },
+        "chatDelivery": {
+          "title": "\u0627\u0644\u062a\u0633\u0644\u064a\u0645 \u062f\u0627\u062e\u0644 \u0627\u0644\u0645\u062d\u0627\u062f\u062b\u0629"
+        }
+      }
+    },
+    "he": {
+      "name": "\u05ea\u05de\u05dc\u05d5\u05dc \u05d4\u05d5\u05d3\u05e2\u05d5\u05ea \u05e7\u05d5\u05dc\u05d9\u05d5\u05ea",
+      "description": "\u05de\u05ea\u05de\u05dc\u05dc \u05d4\u05d5\u05d3\u05e2\u05d5\u05ea \u05e7\u05d5\u05dc\u05d9\u05d5\u05ea \u05e0\u05db\u05e0\u05e1\u05d5\u05ea \u05d1-WhatsApp \u05dc\u05d8\u05e7\u05e1\u05d8 \u05d1\u05d0\u05de\u05e6\u05e2\u05d5\u05ea \u05e9\u05e8\u05ea \u05d3\u05d9\u05d1\u05d5\u05e8-\u05dc\u05d8\u05e7\u05e1\u05d8 \u05ea\u05d5\u05d0\u05dd OpenAI (Speaches/faster-whisper \u05d1\u05d0\u05d9\u05e8\u05d5\u05d7 \u05e2\u05e6\u05de\u05d9 \u05d0\u05d5 Groq/OpenAI \u05d1\u05d0\u05d9\u05e8\u05d5\u05d7) \u05d5\u05de\u05e2\u05d1\u05d9\u05e8 \u05d0\u05d9\u05e8\u05d5\u05e2 `message.transcription` \u05dc-webhook \u05e9\u05dc\u05da \u2014 \u05db\u05da \u05e9\u05d1\u05d5\u05d8\u05d9\u05dd \u05d5-AI \u05d9\u05db\u05d5\u05dc\u05d9\u05dd \u05dc\u05e7\u05e8\u05d5\u05d0 \u05d5\u05dc\u05d4\u05e9\u05d9\u05d1 \u05dc\u05d0\u05d5\u05d3\u05d9\u05d5. \u05de\u05d7\u05d5\u05e5 \u05dc\u05e0\u05ea\u05d9\u05d1 \u05de\u05e1\u05d9\u05e8\u05ea \u05d4\u05d4\u05d5\u05d3\u05e2\u05d5\u05ea; \u05de\u05d5\u05e9\u05d1\u05ea \u05e2\u05d3 \u05e9\u05de\u05d5\u05e4\u05e2\u05dc.",
+      "config": {
+        "sttBaseUrl": {
+          "title": "\u05db\u05ea\u05d5\u05d1\u05ea \u05d1\u05e1\u05d9\u05e1 \u05e9\u05dc STT"
+        },
+        "sttApiKey": {
+          "title": "\u05de\u05e4\u05ea\u05d7 API \u05e9\u05dc STT"
+        },
+        "model": {
+          "title": "\u05de\u05d5\u05d3\u05dc"
+        },
+        "language": {
+          "title": "\u05e8\u05de\u05d6 \u05e9\u05e4\u05d4"
+        },
+        "provider": {
+          "title": "\u05ea\u05d5\u05d5\u05d9\u05ea \u05e1\u05e4\u05e7"
+        },
+        "timeoutMs": {
+          "title": "\u05e4\u05e1\u05e7 \u05d6\u05de\u05df STT (ms)"
+        },
+        "enabledMessageTypes": {
+          "title": "\u05e1\u05d5\u05d2\u05d9 \u05d4\u05d5\u05d3\u05e2\u05d5\u05ea \u05dc\u05ea\u05de\u05dc\u05d5\u05dc"
+        },
+        "maxSizeBytes": {
+          "title": "\u05d2\u05d5\u05d3\u05dc \u05d0\u05d5\u05d3\u05d9\u05d5 \u05de\u05e8\u05d1\u05d9 (\u05d1\u05d9\u05d9\u05d8\u05d9\u05dd)"
+        },
+        "maxPerHour": {
+          "title": "\u05de\u05e7\u05e1\u05d9\u05de\u05d5\u05dd \u05ea\u05de\u05dc\u05d5\u05dc\u05d9\u05dd / \u05e9\u05e2\u05d4 / \u05e1\u05e9\u05df"
+        },
+        "deliveryWebhookUrl": {
+          "title": "\u05db\u05ea\u05d5\u05d1\u05ea webhook \u05dc\u05de\u05e1\u05d9\u05e8\u05d4"
+        },
+        "deliverySecret": {
+          "title": "\u05e1\u05d5\u05d3 \u05de\u05e1\u05d9\u05e8\u05d4"
+        },
+        "deliveryTimeoutMs": {
+          "title": "\u05e4\u05e1\u05e7 \u05d6\u05de\u05df \u05de\u05e1\u05d9\u05e8\u05d4 (ms)"
+        },
+        "chatDelivery": {
+          "title": "\u05de\u05e1\u05d9\u05e8\u05d4 \u05d1\u05ea\u05d5\u05da \u05d4\u05e6'\u05d0\u05d8"
+        }
+      }
+    },
+    "te": {
+      "name": "\u0c35\u0c3e\u0c2f\u0c3f\u0c38\u0c4d \u0c28\u0c4b\u0c1f\u0c4d \u0c1f\u0c4d\u0c30\u0c3e\u0c28\u0c4d\u0c38\u0c4d\u200c\u0c15\u0c4d\u0c30\u0c3f\u0c2a\u0c4d\u0c37\u0c28\u0c4d",
+      "description": "\u0c07\u0c28\u0c4d\u200c\u0c2c\u0c4c\u0c02\u0c21\u0c4d WhatsApp \u0c35\u0c3e\u0c2f\u0c3f\u0c38\u0c4d \u0c28\u0c4b\u0c1f\u0c4d\u200c\u0c32\u0c28\u0c41 OpenAI-\u0c05\u0c28\u0c41\u0c15\u0c42\u0c32 \u0c38\u0c4d\u0c2a\u0c40\u0c1a\u0c4d-\u0c1f\u0c41-\u0c1f\u0c46\u0c15\u0c4d\u0c38\u0c4d\u0c1f\u0c4d \u0c2c\u0c4d\u0c2f\u0c3e\u0c15\u0c4d\u200c\u0c0e\u0c02\u0c21\u0c4d (\u0c38\u0c4d\u0c35\u0c40\u0c2f-\u0c39\u0c4b\u0c38\u0c4d\u0c1f\u0c4d \u0c1a\u0c47\u0c38\u0c3f\u0c28 Speaches/faster-whisper \u0c32\u0c47\u0c26\u0c3e \u0c39\u0c4b\u0c38\u0c4d\u0c1f\u0c4d \u0c1a\u0c47\u0c38\u0c3f\u0c28 Groq/OpenAI) \u0c26\u0c4d\u0c35\u0c3e\u0c30\u0c3e \u0c1f\u0c46\u0c15\u0c4d\u0c38\u0c4d\u0c1f\u0c4d\u200c\u0c17\u0c3e \u0c2e\u0c3e\u0c30\u0c41\u0c38\u0c4d\u0c24\u0c41\u0c02\u0c26\u0c3f \u0c2e\u0c30\u0c3f\u0c2f\u0c41 `message.transcription` \u0c08\u0c35\u0c46\u0c02\u0c1f\u0c4d\u200c\u0c28\u0c41 \u0c2e\u0c40 webhook \u0c15\u0c41 \u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c4d \u0c1a\u0c47\u0c38\u0c4d\u0c24\u0c41\u0c02\u0c26\u0c3f \u2014 \u0c24\u0c26\u0c4d\u0c35\u0c3e\u0c30\u0c3e \u0c2c\u0c3e\u0c1f\u0c4d\u200c\u0c32\u0c41 \u0c2e\u0c30\u0c3f\u0c2f\u0c41 AI \u0c06\u0c21\u0c3f\u0c2f\u0c4b\u0c28\u0c41 \u0c1a\u0c26\u0c35\u0c17\u0c32\u0c35\u0c41 \u0c2e\u0c30\u0c3f\u0c2f\u0c41 \u0c38\u0c4d\u0c2a\u0c02\u0c26\u0c3f\u0c02\u0c1a\u0c17\u0c32\u0c35\u0c41. \u0c38\u0c02\u0c26\u0c47\u0c36-\u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c40 \u0c2e\u0c3e\u0c30\u0c4d\u0c17\u0c02 \u0c28\u0c41\u0c02\u0c21\u0c3f \u0c2c\u0c2f\u0c1f; \u0c2a\u0c4d\u0c30\u0c3e\u0c30\u0c02\u0c2d\u0c3f\u0c02\u0c1a\u0c47 \u0c35\u0c30\u0c15\u0c41 \u0c28\u0c3f\u0c32\u0c3f\u0c2a\u0c3f\u0c35\u0c47\u0c2f\u0c2c\u0c21\u0c3f\u0c02\u0c26\u0c3f.",
+      "config": {
+        "sttBaseUrl": {
+          "title": "STT \u0c2c\u0c47\u0c38\u0c4d URL"
+        },
+        "sttApiKey": {
+          "title": "STT API \u0c15\u0c40"
+        },
+        "model": {
+          "title": "\u0c2e\u0c4b\u0c21\u0c32\u0c4d"
+        },
+        "language": {
+          "title": "\u0c2d\u0c3e\u0c37\u0c3e \u0c38\u0c42\u0c1a\u0c28"
+        },
+        "provider": {
+          "title": "\u0c2a\u0c4d\u0c30\u0c4a\u0c35\u0c48\u0c21\u0c30\u0c4d \u0c32\u0c47\u0c2c\u0c41\u0c32\u0c4d"
+        },
+        "timeoutMs": {
+          "title": "STT \u0c1f\u0c48\u0c2e\u0c4d\u200c\u0c05\u0c35\u0c41\u0c1f\u0c4d (ms)"
+        },
+        "enabledMessageTypes": {
+          "title": "\u0c1f\u0c4d\u0c30\u0c3e\u0c28\u0c4d\u0c38\u0c4d\u200c\u0c15\u0c4d\u0c30\u0c48\u0c2c\u0c4d \u0c1a\u0c47\u0c2f\u0c3e\u0c32\u0c4d\u0c38\u0c3f\u0c28 \u0c38\u0c02\u0c26\u0c47\u0c36 \u0c30\u0c15\u0c3e\u0c32\u0c41"
+        },
+        "maxSizeBytes": {
+          "title": "\u0c17\u0c30\u0c3f\u0c37\u0c4d\u0c1f \u0c06\u0c21\u0c3f\u0c2f\u0c4b \u0c2a\u0c30\u0c3f\u0c2e\u0c3e\u0c23\u0c02 (\u0c2c\u0c48\u0c1f\u0c4d\u0c32\u0c41)"
+        },
+        "maxPerHour": {
+          "title": "\u0c17\u0c30\u0c3f\u0c37\u0c4d\u0c1f \u0c1f\u0c4d\u0c30\u0c3e\u0c28\u0c4d\u0c38\u0c4d\u200c\u0c15\u0c4d\u0c30\u0c3f\u0c2a\u0c4d\u0c37\u0c28\u0c4d\u200c\u0c32\u0c41 / \u0c17\u0c02\u0c1f / \u0c38\u0c46\u0c37\u0c28\u0c4d"
+        },
+        "deliveryWebhookUrl": {
+          "title": "\u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c40 webhook URL"
+        },
+        "deliverySecret": {
+          "title": "\u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c40 \u0c30\u0c39\u0c38\u0c4d\u0c2f\u0c02"
+        },
+        "deliveryTimeoutMs": {
+          "title": "\u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c40 \u0c1f\u0c48\u0c2e\u0c4d\u200c\u0c05\u0c35\u0c41\u0c1f\u0c4d (ms)"
+        },
+        "chatDelivery": {
+          "title": "\u0c1a\u0c3e\u0c1f\u0c4d\u200c\u0c32\u0c4b \u0c21\u0c46\u0c32\u0c3f\u0c35\u0c30\u0c40"
+        }
+      }
+    },
+    "zh-CN": {
+      "name": "\u8bed\u97f3\u6d88\u606f\u8f6c\u5199",
+      "description": "\u901a\u8fc7\u517c\u5bb9 OpenAI \u7684\u8bed\u97f3\u8f6c\u6587\u5b57\u540e\u7aef\uff08\u81ea\u6258\u7ba1 Speaches/faster-whisper \u6216\u6258\u7ba1\u7684 Groq/OpenAI\uff09\u5c06\u4f20\u5165\u7684 WhatsApp \u8bed\u97f3\u6d88\u606f\u8f6c\u5199\u4e3a\u6587\u672c\uff0c\u5e76\u5411\u4f60\u7684 webhook \u6295\u9012 `message.transcription` \u4e8b\u4ef6\u2014\u2014\u8ba9\u673a\u5668\u4eba\u548c AI \u80fd\u591f\u8bfb\u53d6\u5e76\u56de\u590d\u8bed\u97f3\u3002\u4e0d\u5728\u6d88\u606f\u6295\u9012\u8def\u5f84\u4e0a\uff1b\u542f\u7528\u524d\u4fdd\u6301\u7981\u7528\u3002",
+      "config": {
+        "sttBaseUrl": {
+          "title": "STT \u57fa\u7840 URL"
+        },
+        "sttApiKey": {
+          "title": "STT API \u5bc6\u94a5"
+        },
+        "model": {
+          "title": "\u6a21\u578b"
+        },
+        "language": {
+          "title": "\u8bed\u8a00\u63d0\u793a"
+        },
+        "provider": {
+          "title": "\u63d0\u4f9b\u5546\u6807\u7b7e"
+        },
+        "timeoutMs": {
+          "title": "STT \u8d85\u65f6\uff08\u6beb\u79d2\uff09"
+        },
+        "enabledMessageTypes": {
+          "title": "\u8981\u8f6c\u5199\u7684\u6d88\u606f\u7c7b\u578b"
+        },
+        "maxSizeBytes": {
+          "title": "\u6700\u5927\u97f3\u9891\u5927\u5c0f\uff08\u5b57\u8282\uff09"
+        },
+        "maxPerHour": {
+          "title": "\u6bcf\u5c0f\u65f6\u6bcf\u4f1a\u8bdd\u6700\u5927\u8f6c\u5199\u6570"
+        },
+        "deliveryWebhookUrl": {
+          "title": "\u6295\u9012 webhook URL"
+        },
+        "deliverySecret": {
+          "title": "\u6295\u9012\u5bc6\u94a5"
+        },
+        "deliveryTimeoutMs": {
+          "title": "\u6295\u9012\u8d85\u65f6\uff08\u6beb\u79d2\uff09"
+        },
+        "chatDelivery": {
+          "title": "\u804a\u5929\u5185\u6295\u9012"
+        }
+      }
+    },
+    "zh-HK": {
+      "name": "\u8a9e\u97f3\u8a0a\u606f\u8f49\u5beb",
+      "description": "\u900f\u904e\u517c\u5bb9 OpenAI \u7684\u8a9e\u97f3\u8f49\u6587\u5b57\u5f8c\u7aef\uff08\u81ea\u8a17\u7ba1 Speaches/faster-whisper \u6216\u8a17\u7ba1\u7684 Groq/OpenAI\uff09\u5c07\u50b3\u5165\u7684 WhatsApp \u8a9e\u97f3\u8a0a\u606f\u8f49\u5beb\u70ba\u6587\u5b57\uff0c\u4e26\u5411\u4f60\u7684 webhook \u6295\u905e `message.transcription` \u4e8b\u4ef6\u2014\u2014\u8b93\u6a5f\u5668\u4eba\u53ca AI \u80fd\u5920\u8b80\u53d6\u4e26\u56de\u8986\u8a9e\u97f3\u3002\u4e0d\u5728\u8a0a\u606f\u6295\u905e\u8def\u5f91\u4e0a\uff1b\u555f\u7528\u524d\u4fdd\u6301\u505c\u7528\u3002",
+      "config": {
+        "sttBaseUrl": {
+          "title": "STT \u57fa\u790e URL"
+        },
+        "sttApiKey": {
+          "title": "STT API \u91d1\u9470"
+        },
+        "model": {
+          "title": "\u6a21\u578b"
+        },
+        "language": {
+          "title": "\u8a9e\u8a00\u63d0\u793a"
+        },
+        "provider": {
+          "title": "\u63d0\u4f9b\u8005\u6a19\u7c64"
+        },
+        "timeoutMs": {
+          "title": "STT \u903e\u6642\uff08\u6beb\u79d2\uff09"
+        },
+        "enabledMessageTypes": {
+          "title": "\u8981\u8f49\u5beb\u7684\u8a0a\u606f\u985e\u578b"
+        },
+        "maxSizeBytes": {
+          "title": "\u6700\u5927\u97f3\u8a0a\u5927\u5c0f\uff08\u4f4d\u5143\u7d44\uff09"
+        },
+        "maxPerHour": {
+          "title": "\u6bcf\u5c0f\u6642\u6bcf\u5de5\u4f5c\u968e\u6bb5\u6700\u5927\u8f49\u5beb\u6578"
+        },
+        "deliveryWebhookUrl": {
+          "title": "\u6295\u905e webhook URL"
+        },
+        "deliverySecret": {
+          "title": "\u6295\u905e\u5bc6\u9470"
+        },
+        "deliveryTimeoutMs": {
+          "title": "\u6295\u905e\u903e\u6642\uff08\u6beb\u79d2\uff09"
+        },
+        "chatDelivery": {
+          "title": "\u5c0d\u8a71\u5167\u6295\u905e"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
onConfigChange drains the buffer before swapping the client so rows land in the spreadsheet they were captured for. But `flush()` swallows its own failure, so a drain that could not reach Sheets leaves every row in place — and the next flush sends message content captured under one spreadsheet and credential to whichever target the operator just rotated to.

Rows still queued after the drain are now moved to their own storage key and reported once. They are kept rather than discarded, and they never cross the boundary the rotation just drew.

Also clarifies `voice-transcription`'s `chatDelivery: reply`. The description said the transcript is "visible to them"; in a group that is every member, which is worth knowing before switching it on. Behaviour is unchanged and it still defaults to `off`.

## Verification

- 585 tests pass, catalog up to date. The rotation fix is test-first: the test drives a failing drain and asserts the rows are parked, the operator is told, and the live buffer is left empty.