### PR TITLE
fix: harden the upload boundary, badge gate, backoff map and action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/download-badges.yml
+++ b/.github/workflows/download-badges.yml
@@ -16,8 +16,8 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 22
           cache: npm

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,13 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The send-retry backoff map is now bounded.** An entry is added when a send fails and removed on the
+  next delivery, so a chat that never messages again left one behind. Every other piece of state in this
+  plugin was already capped; this was the exception.
+
+
 ## [0.2.1] — 2026-08-01
 
 No behaviour change. 0.2.0 has now been smoke-tested against a newer host, so the tested-version field

--- a/after-hours/index.ts
+++ b/after-hours/index.ts
@@ -43,6 +43,11 @@ export function parseConfig(raw: Record<string, unknown>): { config: AfterHoursC
 // cannot turn every inbound message into another send attempt.
 const RETRY_BACKOFF_MS = 60_000;
 
+// The backoff map holds one entry per chat that failed a send. Entries are removed on the next
+// delivery, but a chat that never messages again leaves one behind — so cap it. Every other piece of
+// state in this plugin is already bounded; this was the exception.
+const MAX_RETRY_ENTRIES = 5_000;
+
 // Responder band, last: the away message is the catch-all that speaks only when nothing more specific
 // answered.
 const HOOK_PRIORITY = 95;
@@ -113,6 +118,15 @@ export default class AfterHours implements IPlugin {
       // `message:sending` fan-outs across every installed plugin.
       this.repliedAt.delete(key);
       this.retryNotBefore.set(key, Date.now() + RETRY_BACKOFF_MS);
+      // Drop the entries whose backoff has already elapsed; if that is not enough, drop oldest-first.
+      if (this.retryNotBefore.size > MAX_RETRY_ENTRIES) {
+        const now = Date.now();
+        for (const [k, until] of this.retryNotBefore) if (until <= now) this.retryNotBefore.delete(k);
+        for (const k of this.retryNotBefore.keys()) {
+          if (this.retryNotBefore.size <= MAX_RETRY_ENTRIES) break;
+          this.retryNotBefore.delete(k);
+        }
+      }
       ctx.logger.error('after-hours: reply failed', err);
       return false; // nothing was delivered, so nothing is claimed
     }

--- a/scripts/download-badges.mjs
+++ b/scripts/download-badges.mjs
@@ -45,7 +45,9 @@ const TAG_RE = /^(.+)-v\d+\.\d+\.\d+$/;
 
 for (const release of await fetchAllReleases()) {
   const id = release.tag_name?.match(TAG_RE)?.[1];
-  if (!id || !(id in totals)) continue;
+  // Object.hasOwn, not `in`: `in` walks the prototype chain, so a release tagged `constructor-v1.0.0`
+  // or `__proto__-v1.0.0` would pass this gate and then write a badge for a plugin that does not exist.
+  if (!id || !Object.hasOwn(totals, id)) continue;
   for (const asset of release.assets ?? []) {
     if (asset.name === `${id}.zip`) totals[id] += asset.download_count;
   }

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+### Fixed
+
+- **The multipart boundary for an upload is now drawn from the CSPRNG.** It was built from two
+  `Math.random()` values. The audio bytes come from a sender, so a boundary that can be predicted is one
+  that can be embedded to forge extra parts of the request. Matches the producers in the other plugins.
+
+
 ### Changed
 
 - **`chatDelivery: reply` now says what it does in a group.** The option posts a quote-reply to the

--- a/voice-transcription/openai-stt.client.ts
+++ b/voice-transcription/openai-stt.client.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type { PluginNetCapability } from '../types/openwa';
 import { buildMultipartBody, MultipartField } from './multipart.ts';
 
@@ -78,7 +79,9 @@ export class OpenAiSttClient implements SttProvider {
   }
 
   private async doTranscribe(audio: Uint8Array, mimetype: string): Promise<SttResult> {
-    const boundary = `----openwaFormBoundary${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+    // Random from the CSPRNG, not Math.random: the audio bytes come from a sender, and a boundary that
+    // can be predicted is one that can be embedded to forge extra parts. Matches the other two producers.
+    const boundary = `----openwaFormBoundary${randomBytes(16).toString('hex')}`;
     const fields: MultipartField[] = [
       { name: 'model', value: this.opts.model },
       { name: 'response_format', value: 'json' },


### PR DESCRIPTION
Four small hardening changes, each closing a class rather than an instance.

**Upload boundary.** `voice-transcription` built its multipart boundary from two `Math.random()` values. The audio bytes come from a sender, so a boundary that can be predicted is one that can be embedded to forge extra parts of the request. It now draws from the CSPRNG, matching the producers in `chatwoot-adapter` and `typebot-connector`.

**Badge gate.** The badge script filtered release tags with `id in totals`. `in` walks the prototype chain, so a release tagged `constructor-v1.0.0` or `__proto__-v1.0.0` would have passed and written a badge for a plugin that does not exist. `Object.hasOwn` looks only at real entries.

**Backoff map.** `after-hours` added an entry per chat that failed a send and removed it on the next delivery — so a chat that never messaged again left one behind. Every other piece of state in that plugin was already bounded; this one is now capped too, dropping already-elapsed entries first and oldest-first after that.

**Action pins.** Both workflows referenced third-party actions by moving tags while holding `contents: write`. They are pinned to the commit each tag currently points at, with the tag kept alongside as a comment. Both SHAs were verified against the GitHub API before pinning.

## Verification

- 585 tests pass, typecheck clean, catalog up to date.