### PR TITLE
fix: keep personal data out of the diagnostics the dashboard renders

### DIFF
--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,13 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The debug log no longer records the text of every incoming message.** The line runs for each inbound
+  message and the dashboard renders plugin logs. It now records the body length, which is what the
+  diagnostic actually uses.
+
+
 ## [1.1.2] — 2026-08-12
 
 ### Changed

--- a/chat-flow/flow-engine.ts
+++ b/chat-flow/flow-engine.ts
@@ -89,7 +89,9 @@ export class FlowEngine {
     messageId: string,
     depth = 0,
   ): Promise<boolean> {
-    context.logger.debug('[FlowEngine] Processing message', { sessionId, chatId, body: messageBody });
+    // Not the message body: this line runs for every inbound message, and the dashboard renders plugin
+    // logs. The length is what a diagnostic actually uses — "did the engine see anything at all".
+    context.logger.debug('[FlowEngine] Processing message', { sessionId, chatId, bodyLength: messageBody.length });
 
     const input = messageBody.trim();
     const stateKey = `state__${sessionId}__${conversation}`.replace(/:/g, '_');

--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ### Fixed
 
+- **Chatwoot request errors no longer carry the customer's phone number.** These errors surface in
+  `healthCheck`, which the dashboard renders, and the contact-search URL carries the number in its query
+  string. The query is dropped and the response body is no longer appended; the path still says which
+  endpoint failed, which is what the diagnostic is for.
 - **An agent reply can no longer reach the wrong customer.** Chatwoot conversation ids are per-account
   autoincrement, so two relayed accounts share one routinely. Alongside the tenant-scoped reverse
   mapping, an unscoped one was rewritten on every link, leaving it pointing at whichever session linked

--- a/chatwoot-adapter/chatwoot-client.ts
+++ b/chatwoot-adapter/chatwoot-client.ts
@@ -1,6 +1,16 @@
 import { randomBytes } from 'node:crypto';
 import { buildMultipartBody } from './multipart.ts';
 
+/**
+ * A request URL with its query string dropped. These errors surface in `healthCheck`, which the
+ * dashboard renders — and the contact-search URL carries the customer's phone number in `?q=`. The path
+ * is all a diagnostic needs: it says which endpoint failed.
+ */
+function redactUrl(url: string): string {
+  const q = url.indexOf('?');
+  return q === -1 ? url : `${url.slice(0, q)}?…`;
+}
+
 export interface ChatwootConfig {
   baseUrl: string;
   apiToken: string;
@@ -44,7 +54,7 @@ export class ChatwootClient {
   ): Promise<{ status: number; data: T }> {
     const res = await this.fetch(url, { ...init, headers: this.headers({ 'Content-Type': 'application/json', ...init?.headers }) });
     if (!res.ok) {
-      const e = new Error(`Chatwoot ${init?.method ?? 'GET'} ${url} -> ${res.status}: ${res.body.slice(0, 300)}`) as Error & {
+      const e = new Error(`Chatwoot ${init?.method ?? 'GET'} ${redactUrl(url)} -> ${res.status}`) as Error & {
         status?: number;
       };
       e.status = res.status;


### PR DESCRIPTION
Two places where a diagnostic carried more than a diagnostic needs.

**Chatwoot request errors** were built with the full request URL and 300 characters of the response body. Those errors surface in `healthCheck`, which the dashboard renders — and the contact-search URL carries the customer's phone number in its query string. The query is now dropped and the body is no longer appended. The path still names the endpoint that failed, which is what the message is read for.

**chat-flow's debug line** recorded the text of every incoming message. It runs for each inbound message, and plugin logs are rendered in the dashboard as well. It now records the body length — which is what the line is actually used for: whether the engine saw anything at all.

Neither change affects behaviour; both narrow what is written down.

## Verification

- 585 tests pass, typecheck clean, catalog up to date.