### PR TITLE
feat: pin #sha256= on catalog downloads and verify all plugins against OpenWA 0.20.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,18 @@ jobs:
       - name: Build & package (validates version↔changelog and size)
         run: node package.mjs "$PLUGIN_ID"
 
+      # The catalog's download URL pins the digest of the artifact this Release attaches, computed from
+      # the same tree by the same deterministic build. If CI ever produces bytes that differ from the
+      # tree that generated plugins.json, every pinned install of this release fails verification on the
+      # host, so fail here instead, before anything is published.
+      - name: The catalog pin matches the artifact
+        run: |
+          PIN=$(node -p "new URL(require('./plugins.json').find(e => e.id === process.env.PLUGIN_ID).download).hash.slice('#sha256='.length)")
+          ACTUAL=$(sha256sum "$PLUGIN_ID.zip" | cut -d' ' -f1)
+          if [ "$PIN" != "$ACTUAL" ]; then
+            echo "catalog pins $PIN but the built artifact is $ACTUAL; regenerate the catalog from this tree"; exit 1
+          fi
+
       # The last point at which a bundle the host cannot load is still cheap to fix. After this step the
       # Release is created and the zip is installable.
       - name: The built bundle loads as a plugin
@@ -70,7 +82,7 @@ jobs:
           ' "$PLUGIN_ID/CHANGELOG.md" > notes.md
           {
             echo ""
-            echo "**Install:** download \`$PLUGIN_ID.zip\` below and upload it in the OpenWA dashboard (Plugins → Install)."
+            echo "**Install:** download \`$PLUGIN_ID.zip\` below and upload it in the OpenWA dashboard (Plugins → Install). For install-from-URL on a production host (OpenWA ≥ 0.20.0), append \`#sha256=<digest below>\` to the asset URL."
             echo ""
             echo "SHA-256: \`$(cut -d' ' -f1 "$PLUGIN_ID.zip.sha256")\`"
           } >> notes.md

--- a/PLUGIN-STANDARD.md
+++ b/PLUGIN-STANDARD.md
@@ -13,7 +13,7 @@ and the storage quota in 0.12, the `storage:use` gate after 0.16).
 | Machine-readable metadata | `manifest.json` | Single source of truth. OpenWA reads required fields and ignores unknown ones. |
 | Human-readable docs | `README.md` | Standard section order (below). |
 | Dated version history | `CHANGELOG.md` | Keep a Changelog + SemVer. The release date lives here. |
-| Computed artifacts (size, sha256) | release time | GitHub Release notes + assets — never hand-written. |
+| Computed artifacts (size, sha256) | release time | GitHub Release notes + assets, plus the `#sha256=` pin on each catalog `download` URL; never hand-written. |
 | Cross-plugin index | `plugins.json` (repo root) | **Generated** from manifests + changelogs. Don't edit by hand. |
 
 ## Repository layout
@@ -366,7 +366,7 @@ One entry per plugin, written by `scripts/catalog.mjs` from each manifest + chan
   "keywords", "minOpenWAVersion", "testedOpenWAVersion",
   "releasedAt",           // from the top CHANGELOG heading
   "repoPath", "repoUrl", "homepage",
-  "download",             // predictable GitHub Release asset URL: <repo>/releases/download/<id>-v<version>/<id>.zip
+  "download",             // predictable GitHub Release asset URL: <repo>/releases/download/<id>-v<version>/<id>.zip#sha256=<digest of the deterministic build; OpenWA ≥ 0.20.0 requires the pin for URL installs in production>
 
   // What the plugin DECLARES it binds — see the caveat below before treating any of it as a guarantee.
   "permissions",          // the capability permissions from the manifest

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ This repository provides:
 <!-- BEGIN PLUGIN CATALOG -->
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
-| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.2 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.3 | stable |
-| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.2 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.2 | stable |
-| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.2 | stable |
-| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.4 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.3 | stable |
-| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.1 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.3 | stable |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.4 | beta |
+| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.3 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.4 | stable |
+| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.3 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.3 | stable |
+| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.3 | stable |
+| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.5 | stable |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.4 | stable |
+| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.2 | beta |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.4 | stable |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.5 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`
@@ -86,6 +86,8 @@ curl -X POST "https://your-openwa-host/api/plugins/install" \
   -H "X-API-Key: <ADMIN_API_KEY>" \
   -F "file=@gsheets-logger.zip"
 ```
+
+Installing from a URL instead of an upload works the same way (`POST /api/plugins/install-url` with `{"url": ...}`). On a production host (OpenWA ≥ 0.20.0, where `NODE_ENV=production`), a URL install additionally requires a `#sha256=<64 hex>` integrity pin on the URL: catalog entries already carry it, and for a hand-pasted release URL the digest is the SHA-256 printed in that plugin's GitHub Release notes (`PLUGIN_INSTALL_REQUIRE_PIN=false` opts out).
 
 **2. Configure it** (secrets are masked on read and preserved on write):
 

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.2.2] — 2026-08-15
 
 ### Fixed

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -13,13 +13,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `after-hours` |
-| **Version** | 0.2.2 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.2.3 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "after-hours",
   "name": "After-Hours Auto-Reply",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": [
     "auto-reply"
   ],

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [1.1.3] — 2026-08-15
 
 ### Fixed

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.1.3 |
-| **Released** | 2026-08-15 |
+| **Version** | 1.1.4 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": [
     "auto-reply"
   ],

--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.9.2] — 2026-08-15
 
 ### Fixed

--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chatwoot-adapter` |
-| **Version** | 0.9.2 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.9.3 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.7 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.8.7 (tested 0.20.0) |
 | **Keywords** | chatwoot, helpdesk, inbox, handover, two-way, agent, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chatwoot-adapter](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter) |
 <!-- END DETAILS -->

--- a/chatwoot-adapter/manifest.json
+++ b/chatwoot-adapter/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwoot-adapter",
   "name": "Chatwoot Adapter",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -12,7 +12,7 @@
   "keywords": ["chatwoot", "helpdesk", "inbox", "handover", "two-way", "agent", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.7",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send", "webhook:ingress", "engine:read",
     "storage:use"],

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.2.2] — 2026-08-15
 
 ### Fixed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.2 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.2.3 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.20.0) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": [
     "auto-reply"
   ],

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [1.3.2] — 2026-08-15
 
 ### Fixed

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `group-translate` |
-| **Version** | 1.3.2 |
-| **Released** | 2026-08-15 |
+| **Version** | 1.3.3 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
 | **Keywords** | translation, libretranslate, i18n, groups, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/group-translate](https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate) |
 <!-- END DETAILS -->

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "group-translate",
   "name": "Group Auto-Translation",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": [
     "translation"
   ],

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.3.4] — 2026-08-15
 
 ### Fixed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `gsheets-logger` |
-| **Version** | 0.3.4 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.3.5 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
 | **Keywords** | google-sheets, logging, audit, crm, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gsheets-logger",
   "name": "Google Sheets Logger",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -12,7 +12,7 @@
   "keywords": ["google-sheets", "logging", "audit", "crm", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": ["message-logging"],
   "permissions": [
     "net:fetch",

--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -5,6 +5,12 @@ and the top entry's version must match `manifest.json`.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.2.3] — 2026-08-15
 
 ### Fixed

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.2.3 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.2.4 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested 0.20.0) |
 | **Keywords** | api, rest, automation, connector, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/http-action](https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action) |
 <!-- END DETAILS -->

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -18,7 +18,7 @@
     "openwa"
   ],
   "status": "stable",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
   "provides": [

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "after-hours",
     "name": "After-Hours Auto-Reply",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -17,12 +17,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.2/after-hours.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.3/after-hours.zip#sha256=04c0b04350b7018cd047a39bb3a381e38ce13b010d16073339649773e0a99aa1",
     "permissions": [
       "messages:send"
     ],
@@ -203,7 +203,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -219,12 +219,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.3/chat-flow.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.4/chat-flow.zip#sha256=bd9dbc418cacbdcda93c24ba4cd58d08254261becd1edfeb8d1262db09049753",
     "permissions": [
       "messages:send",
       "storage:use"
@@ -382,7 +382,7 @@
   {
     "id": "chatwoot-adapter",
     "name": "Chatwoot Adapter",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "type": "extension",
     "status": "stable",
     "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -399,12 +399,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.7",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "chatwoot-adapter",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.2/chatwoot-adapter.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.3/chatwoot-adapter.zip#sha256=55b5f6c1c1169e5b9b23fa561afdb2302e7dd94ec584e1297767727f88d12074",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -695,7 +695,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -710,12 +710,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.2/faq-bot.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.3/faq-bot.zip#sha256=77cd03dcbc3e68a1274267897e97c58b2972f2f31e334c0aa64ad6d9eaf2d4e5",
     "permissions": [
       "messages:send"
     ],
@@ -872,7 +872,7 @@
   {
     "id": "group-translate",
     "name": "Group Auto-Translation",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "type": "extension",
     "status": "stable",
     "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -887,12 +887,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.2/group-translate.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.3/group-translate.zip#sha256=df6a0b407c5c9a9bcc3aee5eca284948925123a3de5cbf26fecf470b88dd7ffb",
     "permissions": [
       "messages:send",
       "engine:read",
@@ -1156,7 +1156,7 @@
   {
     "id": "gsheets-logger",
     "name": "Google Sheets Logger",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "type": "extension",
     "status": "stable",
     "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -1171,12 +1171,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.4/gsheets-logger.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.5/gsheets-logger.zip#sha256=39e46918ec256a983bf9ba3e9095f5e33a8a5c878d2eb1d585c1cefca8f4e086",
     "permissions": [
       "net:fetch",
       "storage:use"
@@ -1363,7 +1363,7 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "type": "extension",
     "status": "stable",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -1378,12 +1378,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.3/http-action.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.4/http-action.zip#sha256=7d6af42f66131f8d6c936bde24dbd441223446eeec09dfc3e671356e9317be3a",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -1643,7 +1643,7 @@
   {
     "id": "supabase-otp-hook",
     "name": "Supabase Auth OTP",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "type": "extension",
     "status": "beta",
     "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -1660,12 +1660,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.16",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "supabase-otp-hook",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.1/supabase-otp-hook.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.2/supabase-otp-hook.zip#sha256=d55e71cf61305fa8d06908aae6bb2a3f64515ebc78df12f275c7abe160723b2f",
     "permissions": [
       "webhook:ingress",
       "messages:send"
@@ -1828,7 +1828,7 @@
   {
     "id": "typebot-connector",
     "name": "Typebot Connector",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "type": "extension",
     "status": "stable",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -1845,12 +1845,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.2",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.3/typebot-connector.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.4/typebot-connector.zip#sha256=8da6ff260927b99bbf0322b5018115510d6f4b55c562d0b459ffc71644b24488",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -2087,7 +2087,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -2104,12 +2104,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.19.0",
-    "releasedAt": "2026-08-15",
+    "testedOpenWAVersion": "0.20.0",
+    "releasedAt": "2026-08-16",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.4/voice-transcription.zip",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.5/voice-transcription.zip#sha256=1301e88d505953890ab9fa0ea27b84363260504330cc44d90fcc2bdaf6e9f249",
     "permissions": [
       "net:fetch",
       "messages:send",

--- a/scripts/catalog.mjs
+++ b/scripts/catalog.mjs
@@ -4,6 +4,8 @@
 //
 // Usage: node scripts/catalog.mjs [--check]
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -129,6 +131,18 @@ function readChangelogTop(id) {
   return { version: m[1], date: m[2] };
 }
 
+// The digest pinned to each catalog download URL. OpenWA ≥ 0.20.0 refuses an install from an unpinned
+// URL in production (fail-closed integrity for third-party code), so the catalog itself must carry the
+// `#sha256=` fragment: the dashboard passes this URL verbatim to install-url. The digest is computed
+// from a fresh package.mjs build (byte-deterministic: verified that a local build equals the GitHub
+// Release asset for the same tree), and the release workflow re-checks the published artifact against
+// this pin before creating the Release, so a diverging build fails loudly instead of shipping a
+// catalog whose pin can never verify.
+function packagedSha256(id) {
+  execFileSync(process.execPath, ['package.mjs', id], { cwd: ROOT, stdio: ['ignore', 'inherit', 'inherit'] });
+  return createHash('sha256').update(readFileSync(join(ROOT, `${id}.zip`))).digest('hex');
+}
+
 function buildEntry(id) {
   const manifest = JSON.parse(readFileSync(join(ROOT, id, 'manifest.json'), 'utf8'));
   const changelog = readChangelogTop(id);
@@ -155,7 +169,7 @@ function buildEntry(id) {
     repoUrl: manifest.repository ?? null,
     homepage: manifest.homepage ?? null,
     download: manifest.repository
-      ? `${manifest.repository}/releases/download/${manifest.id}-v${manifest.version}/${manifest.id}.zip`
+      ? `${manifest.repository}/releases/download/${manifest.id}-v${manifest.version}/${manifest.id}.zip#sha256=${packagedSha256(id)}`
       : null,
     // What the plugin DECLARES it binds. Published so a reader can compare a plugin's stated purpose
     // against the host capabilities it asks for — a mismatch there is a real signal.

--- a/scripts/catalog.test.mjs
+++ b/scripts/catalog.test.mjs
@@ -134,3 +134,24 @@ test('the ingress-declaring plugins publish their route shapes', () => {
     }
   }
 });
+
+// OpenWA ≥ 0.20.0 refuses an install from an unpinned URL in production (NODE_ENV there), fail-closed
+// for third-party code. The dashboard hands `entry.download` to install-url verbatim, so a catalog
+// entry whose URL lost its `#sha256=` fragment ships a link that cannot be installed at all on a
+// production host. Shape only: the digest's equality with the built artifact is enforced by
+// `catalog:check` (which regenerates from a fresh build) and by the release workflow's pin-vs-artifact
+// gate.
+test('every catalog download URL pins the artifact digest', () => {
+  const catalog = JSON.parse(readFileSync(new URL('../plugins.json', import.meta.url), 'utf8'));
+  const entries = catalog.plugins ?? catalog;
+
+  assert.ok(entries.length > 0, 'plugins.json lists no entries, so the pin check would examine nothing');
+  for (const e of entries) {
+    if (!e.download) continue; // a repository-less development plugin has nothing to pin
+    assert.match(
+      e.download,
+      /#sha256=[0-9a-f]{64}$/,
+      `${e.id}: download URL must end in #sha256=<64 hex> (unpinned URLs fail production installs)`,
+    );
+  }
+});

--- a/supabase-otp-hook/CHANGELOG.md
+++ b/supabase-otp-hook/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.3.1] — 2026-08-15
 
 ### Fixed

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `supabase-otp-hook` |
-| **Version** | 0.3.1 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.3.2 |
+| **Released** | 2026-08-16 |
 | **Status** | beta |
 | **Author** | maplerichie |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.16 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.8.16 (tested 0.20.0) |
 | **Keywords** | supabase, auth, otp, sms, whatsapp, verification, standard-webhooks, openwa |
 | **Repository** | [OpenWA-plugins/supabase-otp-hook](https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook) |
 <!-- END DETAILS -->

--- a/supabase-otp-hook/manifest.json
+++ b/supabase-otp-hook/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "supabase-otp-hook",
   "name": "Supabase Auth OTP",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -12,7 +12,7 @@
   "keywords": ["supabase", "auth", "otp", "sms", "whatsapp", "verification", "standard-webhooks", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.8.16",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "sdkVersion": "1",
   "permissions": ["webhook:ingress", "messages:send"],
   "sessionScoped": true,

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Typebot Connector plugin are documented here. The for
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [0.2.3] — 2026-08-15
 
 ### Fixed

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `typebot-connector` |
-| **Version** | 0.2.3 |
-| **Released** | 2026-08-15 |
+| **Version** | 0.2.4 |
+| **Released** | 2026-08-16 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.2 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.8.2 (tested 0.20.0) |
 | **Keywords** | typebot, chatbot, flow, bot, no-code, two-way, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/typebot-connector](https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector) |
 <!-- END DETAILS -->

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "typebot-connector",
   "name": "Typebot Connector",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -12,7 +12,7 @@
   "keywords": ["typebot", "chatbot", "flow", "bot", "no-code", "two-way", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.2",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send",
     "storage:use"],

--- a/types/openwa.d.ts
+++ b/types/openwa.d.ts
@@ -1,12 +1,15 @@
 // Vendored OpenWA plugin contract. There is no published @openwa SDK package; keep this in sync
 // with the OpenWA version you target. All imports of this module must be `import type`.
 //
-// Last aligned against OpenWA core v0.19.0 (tag), verified field-by-field against
+// Last aligned against OpenWA core v0.20.0 (tag), verified field-by-field against
 // src/core/plugins/plugin.interfaces.ts, src/core/hooks/hook.interfaces.ts, plugin-net.ts,
 // sandbox/{worker-bootstrap,worker-capability,worker-hooks,worker-webhooks}.ts and
 // src/engine/interfaces/whatsapp-engine.interface.ts. Where this file narrows the host on purpose it
 // says so; where the host is stricter than this file, the comment names the runtime consequence.
-// The 0.14.5 → 0.19.0 diff over those files changes no member this file tracks: the one behavioral
+// The 0.19.0 → 0.20.0 diff over those files is empty; 0.20.0's plugin-facing changes live elsewhere
+// (the production #sha256 pin on URL installs in plugin-download.ts, ingress text/plain reflections,
+// credential-dir modes) and none of them alter a member this file tracks. The 0.14.5 → 0.19.0 diff
+// over those files changes no member this file tracks either: the one behavioral
 // addition in that range — the "storage:use" gate on ctx.storage — was already vendored above. That
 // alignment also fixed two SILENT OMISSIONS that had survived every earlier pass: `manifest.sdkVersion`
 // and the typed `manifest.ingress` route (with IngressSignatureSpec / IngressResponseContract), both

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-08-16
+
+### Changed
+
+- **Verified against OpenWA v0.20.0** (testedOpenWAVersion 0.19.0 → 0.20.0); the catalog download URL now pins #sha256= for production installs.
+
 ## [1.2.4] — 2026-08-15
 
 ### Fixed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.2.4 |
-| **Released** | 2026-08-15 |
+| **Version** | 1.2.5 |
+| **Released** | 2026-08-16 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.19.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
 | **Keywords** | transcription, speech-to-text, stt, whisper, voice, audio, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/voice-transcription](https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription) |
 <!-- END DETAILS -->

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook \u2014 so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -21,7 +21,7 @@
   ],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.19.0",
+  "testedOpenWAVersion": "0.20.0",
   "provides": [
     "transcription"
   ],


### PR DESCRIPTION
OpenWA 0.20.0 makes a plugin install from a URL fail closed in production unless the URL carries a `#sha256=<64 hex>` content pin. The dashboard installs straight from the catalog's `download` link, so every catalog entry shipped an install that a production host now refuses. This pins the catalog and cuts the releases that carry it.

**The catalog now publishes pinned URLs.** `catalog.mjs` builds each plugin through `package.mjs` and pins the artifact digest into the `download` URL. The build is byte-deterministic (a local build of `gsheets-logger` 0.3.4 hashes identically to its published release asset), so the digest computed at catalog time is the digest the release will attach. `catalog:check` regenerates from a fresh build, which makes a stale pin a hard failure instead of a silently wrong one.

**The release path guards the pin.** After building the artifact, the workflow compares its digest against the catalog's pin and fails before the Release is created if they disagree, so a build that diverges from the catalog tree never publishes a pin that cannot verify. The release notes now tell URL installs to append the digest the same notes print.

**All ten plugins cut a PATCH release.** `testedOpenWAVersion` moves 0.19.0 → 0.20.0 across the catalog; no plugin code changed, because none of the 0.20.0 breaking changes reach the plugin runtime: the loader, sandbox, manifest validation and capability surface are untouched between the tags, and the pin requirement lives in the download funnel. Pinned URLs are backward compatible: 0.19.0 already parsed and verified the fragment, so older hosts gain the verification rather than a rejection.

**Compatibility was verified against a running 0.20.0 host**, not just the tags: all ten plugins install, take config, enable and register their hooks; `supabase-otp-hook` receives a signed ingress delivery through the full verify, dedup, enqueue and worker-dispatch path; and pinned install-url and update both succeed under `PLUGIN_INSTALL_REQUIRE_PIN=true`, while unpinned and wrongly pinned URLs are rejected. The vendored contract header records the 0.20.0 alignment: the diff over the six vendored host files is empty.

## Verification

- 587 tests pass, typecheck clean, catalog regenerated and drift-free (`catalog:check`), all ten bundles build and pass the loader contract.
- Live host at 0.20.0: install, config and enable for all ten plugins, hook registration, signed ingress round trip, and pinned install-url and update through the production pin requirement.

## Release

Ten tags, each pushed on its own so its release run triggers: `after-hours-v0.2.3`, `chat-flow-v1.1.4`, `chatwoot-adapter-v0.9.3`, `faq-bot-v0.2.3`, `group-translate-v1.3.3`, `gsheets-logger-v0.3.5`, `http-action-v0.2.4`, `supabase-otp-hook-v0.3.2`, `typebot-connector-v0.2.4`, `voice-transcription-v1.2.5`. Push the tags before merging so the pinned URLs resolve from the moment the catalog goes live on `main`.
