### PR TITLE
chore: verify all plugins against OpenWA 0.22.0 and fix the supabase secret wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ This repository provides:
 <!-- BEGIN PLUGIN CATALOG -->
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
-| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.3 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.4 | stable |
-| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.3 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.3 | stable |
-| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.3 | stable |
-| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.5 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.4 | stable |
-| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.2 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.4 | stable |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.5 | beta |
+| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.4 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.5 | stable |
+| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.4 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.4 | stable |
+| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.4 | stable |
+| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.6 | stable |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.5 | stable |
+| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.3 | beta |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.5 | stable |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.6 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.2.3] - 2026-08-16
 
 ### Changed

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -13,13 +13,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `after-hours` |
-| **Version** | 0.2.3 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.2.4 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "after-hours",
   "name": "After-Hours Auto-Reply",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": [
     "auto-reply"
   ],

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [1.1.4] - 2026-08-16
 
 ### Changed

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.1.4 |
-| **Released** | 2026-08-16 |
+| **Version** | 1.1.5 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": [
     "auto-reply"
   ],

--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.9.3] - 2026-08-16
 
 ### Changed

--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chatwoot-adapter` |
-| **Version** | 0.9.3 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.9.4 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.7 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.8.7 (tested 0.22.0) |
 | **Keywords** | chatwoot, helpdesk, inbox, handover, two-way, agent, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chatwoot-adapter](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter) |
 <!-- END DETAILS -->

--- a/chatwoot-adapter/manifest.json
+++ b/chatwoot-adapter/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwoot-adapter",
   "name": "Chatwoot Adapter",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -12,7 +12,7 @@
   "keywords": ["chatwoot", "helpdesk", "inbox", "handover", "two-way", "agent", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.7",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send", "webhook:ingress", "engine:read",
     "storage:use"],

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.2.3] - 2026-08-16
 
 ### Changed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.3 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.2.4 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.22.0) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": [
     "auto-reply"
   ],

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [1.3.3] - 2026-08-16
 
 ### Changed

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `group-translate` |
-| **Version** | 1.3.3 |
-| **Released** | 2026-08-16 |
+| **Version** | 1.3.4 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
 | **Keywords** | translation, libretranslate, i18n, groups, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/group-translate](https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate) |
 <!-- END DETAILS -->

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "group-translate",
   "name": "Group Auto-Translation",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": [
     "translation"
   ],

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.3.5] - 2026-08-16
 
 ### Changed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `gsheets-logger` |
-| **Version** | 0.3.5 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.3.6 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
 | **Keywords** | google-sheets, logging, audit, crm, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gsheets-logger",
   "name": "Google Sheets Logger",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -12,7 +12,7 @@
   "keywords": ["google-sheets", "logging", "audit", "crm", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": ["message-logging"],
   "permissions": [
     "net:fetch",

--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -5,6 +5,12 @@ and the top entry's version must match `manifest.json`.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.2.4] - 2026-08-16
 
 ### Changed

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.2.4 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.2.5 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested 0.22.0) |
 | **Keywords** | api, rest, automation, connector, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/http-action](https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action) |
 <!-- END DETAILS -->

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -18,7 +18,7 @@
     "openwa"
   ],
   "status": "stable",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
   "provides": [

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "after-hours",
     "name": "After-Hours Auto-Reply",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -17,12 +17,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.3/after-hours.zip#sha256=04c0b04350b7018cd047a39bb3a381e38ce13b010d16073339649773e0a99aa1",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.4/after-hours.zip#sha256=ffcf2643e88bf181a3d1f75885a8f70d70d18c5080da62bdf718ef228f68534f",
     "permissions": [
       "messages:send"
     ],
@@ -203,7 +203,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -219,12 +219,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.4/chat-flow.zip#sha256=bd9dbc418cacbdcda93c24ba4cd58d08254261becd1edfeb8d1262db09049753",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.5/chat-flow.zip#sha256=2f73c9850ef7b22100c9ec8630e47287cc8dcc271484d0b21884339b885d0a66",
     "permissions": [
       "messages:send",
       "storage:use"
@@ -382,7 +382,7 @@
   {
     "id": "chatwoot-adapter",
     "name": "Chatwoot Adapter",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "type": "extension",
     "status": "stable",
     "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -399,12 +399,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.7",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "chatwoot-adapter",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.3/chatwoot-adapter.zip#sha256=55b5f6c1c1169e5b9b23fa561afdb2302e7dd94ec584e1297767727f88d12074",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.4/chatwoot-adapter.zip#sha256=4b6d0a61f020b44057ed20b9f4d6573ef169544faae6f57a0162454f04e4b33e",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -695,7 +695,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -710,12 +710,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.3/faq-bot.zip#sha256=77cd03dcbc3e68a1274267897e97c58b2972f2f31e334c0aa64ad6d9eaf2d4e5",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.4/faq-bot.zip#sha256=5cbafc44ea91aa89918d79c1c2280f51641dd1cd8e6b5987031a7f86b2e50bcd",
     "permissions": [
       "messages:send"
     ],
@@ -872,7 +872,7 @@
   {
     "id": "group-translate",
     "name": "Group Auto-Translation",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "type": "extension",
     "status": "stable",
     "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -887,12 +887,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.3/group-translate.zip#sha256=df6a0b407c5c9a9bcc3aee5eca284948925123a3de5cbf26fecf470b88dd7ffb",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.4/group-translate.zip#sha256=59af210cd868cbcd649dc1b11327b2ec92faf7bbcb1ade8635dbebf365a2a97c",
     "permissions": [
       "messages:send",
       "engine:read",
@@ -1156,7 +1156,7 @@
   {
     "id": "gsheets-logger",
     "name": "Google Sheets Logger",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "type": "extension",
     "status": "stable",
     "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -1171,12 +1171,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.5/gsheets-logger.zip#sha256=39e46918ec256a983bf9ba3e9095f5e33a8a5c878d2eb1d585c1cefca8f4e086",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.6/gsheets-logger.zip#sha256=4e5878093e7b1e0a8a6478e06088928188e08060a8cdd484f9639784afa9833a",
     "permissions": [
       "net:fetch",
       "storage:use"
@@ -1363,7 +1363,7 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "extension",
     "status": "stable",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -1378,12 +1378,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.4/http-action.zip#sha256=7d6af42f66131f8d6c936bde24dbd441223446eeec09dfc3e671356e9317be3a",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.5/http-action.zip#sha256=691e8ade89982afd4bf0f8e74428dd5b2c55ed3da270c8cab41dba2654cc8660",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -1643,7 +1643,7 @@
   {
     "id": "supabase-otp-hook",
     "name": "Supabase Auth OTP",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "type": "extension",
     "status": "beta",
     "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -1660,12 +1660,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.16",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "supabase-otp-hook",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.2/supabase-otp-hook.zip#sha256=d55e71cf61305fa8d06908aae6bb2a3f64515ebc78df12f275c7abe160723b2f",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.3/supabase-otp-hook.zip#sha256=ade0e7146a3edc232b9b84e582750cb6a62da3b4d90e1586a2f3e5ba759f73e1",
     "permissions": [
       "webhook:ingress",
       "messages:send"
@@ -1828,7 +1828,7 @@
   {
     "id": "typebot-connector",
     "name": "Typebot Connector",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "extension",
     "status": "stable",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -1845,12 +1845,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.2",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.4/typebot-connector.zip#sha256=8da6ff260927b99bbf0322b5018115510d6f4b55c562d0b459ffc71644b24488",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.5/typebot-connector.zip#sha256=1107e5dc59c1ecf6a7624b583d0f4b14259a8c41be3a6b943742af0854a9a5a0",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -2087,7 +2087,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -2104,12 +2104,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.20.0",
-    "releasedAt": "2026-08-16",
+    "testedOpenWAVersion": "0.22.0",
+    "releasedAt": "2026-08-19",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.5/voice-transcription.zip#sha256=1301e88d505953890ab9fa0ea27b84363260504330cc44d90fcc2bdaf6e9f249",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.6/voice-transcription.zip#sha256=d6b1465ed5940026df58f47332842a66232210f58f2f1e04dd1ffaf2e72bf503",
     "permissions": [
       "net:fetch",
       "messages:send",

--- a/supabase-otp-hook/CHANGELOG.md
+++ b/supabase-otp-hook/CHANGELOG.md
@@ -7,6 +7,16 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-19
+
+### Fixed
+
+- **Setup step 4 no longer tells you to PATCH the instance secret.** The host instance API accepts `secret` only at create time (or via `regenerate-secret`); the PATCH endpoint rejects the field with a 400, so the documented wiring dead-ended. The guide now wires the secret at mint time.
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.3.2] - 2026-08-16
 
 ### Changed

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `supabase-otp-hook` |
-| **Version** | 0.3.2 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.3.3 |
+| **Released** | 2026-08-19 |
 | **Status** | beta |
 | **Author** | maplerichie |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.16 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.8.16 (tested 0.22.0) |
 | **Keywords** | supabase, auth, otp, sms, whatsapp, verification, standard-webhooks, openwa |
 | **Repository** | [OpenWA-plugins/supabase-otp-hook](https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook) |
 <!-- END DETAILS -->
@@ -71,9 +71,10 @@ curl -X PUT "$OPENWA/api/plugins/supabase-otp-hook/config" \
 
 Then wire the connection:
 
-Wiring order: OpenWA mints the **ingress URL** → paste into Supabase → Supabase generates the
-**webhook secret** → paste it back into OpenWA **as the instance secret** (the host uses it to verify
-the Standard Webhooks signature).
+Wiring order: OpenWA mints the **ingress URL** and the **instance secret** together → paste the URL
+into Supabase → paste the secret into the Supabase hook form (the host uses it to verify the Standard
+Webhooks signature). The reverse order works too: generate the secret in Supabase first and pass it
+to the mint call.
 
 **1. Mint an OpenWA instance.** Creates the ingress URL and binds the sending session.
 
@@ -94,27 +95,25 @@ curl -X POST "$OPENWA/api/integration/plugins/supabase-otp-hook/instances" \
   -d '{
     "instanceId": "default",
     "sessionScope": "<whatsapp-session-id>",
+    "secret": "v1,whsec_<base64>",
     "config": { "appName": "Acme" }
   }'
 ```
 
-Copy the **ingress URL** from the response: `https://<host>/api/ingress/supabase-otp-hook/default/send-sms`.
+`secret` is optional: omit it and OpenWA auto-generates one, revealing the plaintext once in the
+create response. Either way, copy the **ingress URL** and the **plaintext secret** from the response:
+`https://<host>/api/ingress/supabase-otp-hook/default/send-sms`.
 
-**2. Create the Supabase Send SMS hook.** Dashboard → Authentication → Auth Hooks → Add hook → Send SMS hook → HTTPS. Paste the ingress URL.
+> The secret can only be set here or through `POST .../instances/:id/regenerate-secret` (which also
+> reveals the new plaintext once). The instance PATCH endpoint accepts `enabled`, `sessionScope` and
+> `config` only; it rejects a `secret` field with a 400. The secret is re-read per delivery, so a
+> regenerate needs no restart (paste the new value into Supabase).
 
-**3. Generate the webhook secret.** On the Supabase hook form, click Generate secret. Copy the full `v1,whsec_<base64>` (include the prefix). Save the hook.
+**2. Create the Supabase Send SMS hook.** Dashboard → Authentication → Auth Hooks → Add hook → Send SMS hook → HTTPS. Paste the ingress URL, and set the hook's secret to the instance secret from step 1 (Supabase's form accepts a pasted secret; its Generate secret button is the alternative, used before minting the instance).
 
-**4. Set the secret as the OpenWA instance secret.** This is what the host verifies the signature against — it is *not* plugin config. Paste `v1,whsec_...` into the instance `secret`. The secret is re-read per delivery — no restart.
+**3. Enable phone auth.** Supabase → Authentication → Providers → Phone → enable, set SMS provider to the hook.
 
-```bash
-curl -X PATCH "$OPENWA/api/integration/plugins/supabase-otp-hook/instances/default" \
-  -H "Authorization: Bearer $ADMIN_KEY" -H "Content-Type: application/json" \
-  -d '{"secret":"v1,whsec_..."}'
-```
-
-**5. Enable phone auth.** Supabase → Authentication → Providers → Phone → enable, set SMS provider to the hook.
-
-**6. Test.** Trigger a phone-OTP sign-in. Supabase receives 200 and the OTP arrives in WhatsApp. A dead WhatsApp session yields 503 (visible to Supabase); a bad signature yields 401.
+**4. Test.** Trigger a phone-OTP sign-in. Supabase receives 200 and the OTP arrives in WhatsApp. A dead WhatsApp session yields 503 (visible to Supabase); a bad signature yields 401.
 
 ## Install
 
@@ -144,7 +143,8 @@ curl -X POST "$OPENWA/api/plugins/supabase-otp-hook/enable" \
 | `fallbackSessionId` | string | yes if `sessionScope` blank | Sending session when the instance isn't bound. Ignored when `sessionScope` is set. |
 | `debug` | boolean | no (default `false`) | Log inbound deliveries (resolved session/chatId), sends, and send failures. |
 
-The Supabase webhook secret is set as the **instance `secret`** (at mint time or via PATCH), not in
+The Supabase webhook secret is set as the **instance `secret`** (at mint time or via
+`regenerate-secret`; the PATCH endpoint does not accept it), not in
 this config — the host uses it to verify the Standard Webhooks signature before the handler runs.
 Session scope (which session sends) is also set at instance mint time, not in this config.
 

--- a/supabase-otp-hook/manifest.json
+++ b/supabase-otp-hook/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "supabase-otp-hook",
   "name": "Supabase Auth OTP",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -12,7 +12,7 @@
   "keywords": ["supabase", "auth", "otp", "sms", "whatsapp", "verification", "standard-webhooks", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.8.16",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "sdkVersion": "1",
   "permissions": ["webhook:ingress", "messages:send"],
   "sessionScoped": true,

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Typebot Connector plugin are documented here. The for
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [0.2.4] - 2026-08-16
 
 ### Changed

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `typebot-connector` |
-| **Version** | 0.2.4 |
-| **Released** | 2026-08-16 |
+| **Version** | 0.2.5 |
+| **Released** | 2026-08-19 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.2 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.8.2 (tested 0.22.0) |
 | **Keywords** | typebot, chatbot, flow, bot, no-code, two-way, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/typebot-connector](https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector) |
 <!-- END DETAILS -->

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "typebot-connector",
   "name": "Typebot Connector",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -12,7 +12,7 @@
   "keywords": ["typebot", "chatbot", "flow", "bot", "no-code", "two-way", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.2",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send",
     "storage:use"],

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-08-19
+
+### Changed
+
+- **Verified against OpenWA v0.22.0** (testedOpenWAVersion 0.20.0 → 0.22.0).
+
 ## [1.2.5] - 2026-08-16
 
 ### Changed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.2.5 |
-| **Released** | 2026-08-16 |
+| **Version** | 1.2.6 |
+| **Released** | 2026-08-19 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.20.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
 | **Keywords** | transcription, speech-to-text, stt, whisper, voice, audio, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/voice-transcription](https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription) |
 <!-- END DETAILS -->

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook \u2014 so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -21,7 +21,7 @@
   ],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.20.0",
+  "testedOpenWAVersion": "0.22.0",
   "provides": [
     "transcription"
   ],


### PR DESCRIPTION
OpenWA v0.22.0 is out and the catalog still records every plugin as tested
against 0.20.0. Along the way the supabase-otp-hook setup guide was found
documenting a `PATCH {"secret": ...}` call the instance API has never
accepted: the endpoint answers 400, so the wiring dead-ends before the hook
ever signs.

What changed:

- All ten plugins cut a PATCH release carrying `testedOpenWAVersion`
  0.22.0. No plugin code changed: `src/core` and `src/modules/plugins` are
  byte-identical between the v0.20.0 and v0.22.0 tags, and the vendored
  types match the unchanged interfaces.
- supabase-otp-hook: the setup guide now wires the ingress secret at mint
  time or via `regenerate-secret`, the only two paths the instance API
  offers, instead of the rejected PATCH.
- Catalog regenerated: `plugins.json`, README tables, and `#sha256=`
  download pins for the ten new artifacts. `catalog --check` rebuilds each
  plugin and compares, the same check release.yml runs before publishing.

Versions: after-hours 0.2.4, chat-flow 1.1.5, chatwoot-adapter 0.9.4,
faq-bot 0.2.4, group-translate 1.3.4, gsheets-logger 0.3.6, http-action
0.2.5, supabase-otp-hook 0.3.3, typebot-connector 0.2.5,
voice-transcription 1.2.6.

Verified against a host built from the v0.22.0 tag (isolated SQLite, queue
off): install, config and enable for all ten plugins with hooks registered
per manifest; signed ingress on supabase-otp-hook answering 401 on a bad
signature, 503 on the dead-session preflight, 200 with inline dispatch,
and `duplicate` on a replayed `webhook-id`; a rebuilt release artifact
(faq-bot 0.2.4) installed and enabled cleanly. Repo gates: 587/587 tests,
`tsc --noEmit`, `loader:check`, `catalog:check`, all green.

After merge, each `<plugin>-vX.Y.Z` tag should be pushed individually to
trigger the ten release workflows.