### PR TITLE
chore: verify all plugins against OpenWA 0.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ This repository provides:
 <!-- BEGIN PLUGIN CATALOG -->
 | Plugin | Description | Version | Status |
 | ------ | ----------- | ------- | ------ |
-| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.4 | stable |
-| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.5 | stable |
-| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.4 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.4 | stable |
-| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.4 | stable |
-| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.6 | stable |
-| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.5 | stable |
-| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.3 | beta |
-| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.5 | stable |
-| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.6 | beta |
+| [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.5 | stable |
+| [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.6 | stable |
+| [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.5 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.5 | stable |
+| [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.5 | stable |
+| [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.7 | stable |
+| [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.6 | stable |
+| [`supabase-otp-hook`](./supabase-otp-hook) | Deliver Supabase Auth phone OTPs over WhatsApp. | 0.3.4 | beta |
+| [`typebot-connector`](./typebot-connector) | Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required. | 0.2.6 | stable |
+| [`voice-transcription`](./voice-transcription) | Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled. | 1.2.7 | beta |
 <!-- END PLUGIN CATALOG -->
 
 The table above is generated from each plugin's `manifest.json` + `CHANGELOG.md` by `npm run catalog`

--- a/after-hours/CHANGELOG.md
+++ b/after-hours/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.2.4] - 2026-08-19
 
 ### Changed

--- a/after-hours/README.md
+++ b/after-hours/README.md
@@ -13,13 +13,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `after-hours` |
-| **Version** | 0.2.4 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.2.5 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.23.0) |
 | **Keywords** | after-hours, business-hours, away, auto-reply, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/after-hours](https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours) |
 <!-- END DETAILS -->

--- a/after-hours/manifest.json
+++ b/after-hours/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "after-hours",
   "name": "After-Hours Auto-Reply",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": [
     "auto-reply"
   ],

--- a/chat-flow/CHANGELOG.md
+++ b/chat-flow/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [1.1.5] - 2026-08-19
 
 ### Changed

--- a/chat-flow/README.md
+++ b/chat-flow/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chat-flow` |
-| **Version** | 1.1.5 |
-| **Released** | 2026-08-19 |
+| **Version** | 1.1.6 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.23.0) |
 | **Keywords** | menu, flow, interactive, auto-reply, chatbot, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chat-flow](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow) |
 <!-- END DETAILS -->

--- a/chat-flow/manifest.json
+++ b/chat-flow/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chat-flow",
   "name": "Chat Flow",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -20,7 +20,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": [
     "auto-reply"
   ],

--- a/chatwoot-adapter/CHANGELOG.md
+++ b/chatwoot-adapter/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Chatwoot Adapter plugin are documented here. The form
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.9.4] - 2026-08-19
 
 ### Changed

--- a/chatwoot-adapter/README.md
+++ b/chatwoot-adapter/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `chatwoot-adapter` |
-| **Version** | 0.9.4 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.9.5 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.7 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.8.7 (tested 0.23.0) |
 | **Keywords** | chatwoot, helpdesk, inbox, handover, two-way, agent, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/chatwoot-adapter](https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter) |
 <!-- END DETAILS -->

--- a/chatwoot-adapter/manifest.json
+++ b/chatwoot-adapter/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "chatwoot-adapter",
   "name": "Chatwoot Adapter",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -12,7 +12,7 @@
   "keywords": ["chatwoot", "helpdesk", "inbox", "handover", "two-way", "agent", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.7",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send", "webhook:ingress", "engine:read",
     "storage:use"],

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.2.4] - 2026-08-19
 
 ### Changed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.4 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.2.5 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.6.1 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.6.1 (tested 0.23.0) |
 | **Keywords** | faq, auto-reply, chatbot, support, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/faq-bot](https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot) |
 <!-- END DETAILS -->

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.6.1",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": [
     "auto-reply"
   ],

--- a/group-translate/CHANGELOG.md
+++ b/group-translate/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.3.5] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [1.3.4] - 2026-08-19
 
 ### Changed

--- a/group-translate/README.md
+++ b/group-translate/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `group-translate` |
-| **Version** | 1.3.4 |
-| **Released** | 2026-08-19 |
+| **Version** | 1.3.5 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.23.0) |
 | **Keywords** | translation, libretranslate, i18n, groups, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/group-translate](https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate) |
 <!-- END DETAILS -->

--- a/group-translate/manifest.json
+++ b/group-translate/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "group-translate",
   "name": "Group Auto-Translation",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -19,7 +19,7 @@
   ],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": [
     "translation"
   ],

--- a/gsheets-logger/CHANGELOG.md
+++ b/gsheets-logger/CHANGELOG.md
@@ -8,6 +8,12 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.3.6] - 2026-08-19
 
 ### Changed

--- a/gsheets-logger/README.md
+++ b/gsheets-logger/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `gsheets-logger` |
-| **Version** | 0.3.6 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.3.7 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.23.0) |
 | **Keywords** | google-sheets, logging, audit, crm, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/gsheets-logger](https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger) |
 <!-- END DETAILS -->

--- a/gsheets-logger/manifest.json
+++ b/gsheets-logger/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gsheets-logger",
   "name": "Google Sheets Logger",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -12,7 +12,7 @@
   "keywords": ["google-sheets", "logging", "audit", "crm", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": ["message-logging"],
   "permissions": [
     "net:fetch",

--- a/http-action/CHANGELOG.md
+++ b/http-action/CHANGELOG.md
@@ -5,6 +5,12 @@ and the top entry's version must match `manifest.json`.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.2.5] - 2026-08-19
 
 ### Changed

--- a/http-action/README.md
+++ b/http-action/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `http-action` |
-| **Version** | 0.2.5 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.2.6 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.8.0 (tested 0.23.0) |
 | **Keywords** | api, rest, automation, connector, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/http-action](https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action) |
 <!-- END DETAILS -->

--- a/http-action/manifest.json
+++ b/http-action/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "http-action",
   "name": "HTTP Action Bot",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -18,7 +18,7 @@
     "openwa"
   ],
   "status": "stable",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "minOpenWAVersion": "0.8.0",
   "sdkVersion": "1",
   "provides": [

--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "after-hours",
     "name": "After-Hours Auto-Reply",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies with a configurable away/closing message to messages received outside business hours.",
@@ -17,12 +17,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "after-hours",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/after-hours",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.4/after-hours.zip#sha256=ffcf2643e88bf181a3d1f75885a8f70d70d18c5080da62bdf718ef228f68534f",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/after-hours-v0.2.5/after-hours.zip#sha256=6d7f987d753c49252e1420252c0c8697c1a051eec3205df65b35be0f3cb93b58",
     "permissions": [
       "messages:send"
     ],
@@ -203,7 +203,7 @@
   {
     "id": "chat-flow",
     "name": "Chat Flow",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "type": "extension",
     "status": "stable",
     "description": "Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes.",
@@ -219,12 +219,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "chat-flow",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chat-flow",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.5/chat-flow.zip#sha256=2f73c9850ef7b22100c9ec8630e47287cc8dcc271484d0b21884339b885d0a66",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chat-flow-v1.1.6/chat-flow.zip#sha256=d7b4db02ad4922460964f14f15f93bd4b72bfac1dd4e46108b53d283930c2f0b",
     "permissions": [
       "messages:send",
       "storage:use"
@@ -382,7 +382,7 @@
   {
     "id": "chatwoot-adapter",
     "name": "Chatwoot Adapter",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "type": "extension",
     "status": "stable",
     "description": "Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker.",
@@ -399,12 +399,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.7",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "chatwoot-adapter",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/chatwoot-adapter",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.4/chatwoot-adapter.zip#sha256=4b6d0a61f020b44057ed20b9f4d6573ef169544faae6f57a0162454f04e4b33e",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/chatwoot-adapter-v0.9.5/chatwoot-adapter.zip#sha256=c866bbc7a3ebdfee4136c7bfdfe31e1d6c345a32081f561ca8542a0364dedf27",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -695,7 +695,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -710,12 +710,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.6.1",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.4/faq-bot.zip#sha256=5cbafc44ea91aa89918d79c1c2280f51641dd1cd8e6b5987031a7f86b2e50bcd",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.5/faq-bot.zip#sha256=50e71bcd2f724d6143294f7c9d2e60c88a3e5b3afadbdad63f6b42bf79d16e40",
     "permissions": [
       "messages:send"
     ],
@@ -872,7 +872,7 @@
   {
     "id": "group-translate",
     "name": "Group Auto-Translation",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "type": "extension",
     "status": "stable",
     "description": "Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled.",
@@ -887,12 +887,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "group-translate",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/group-translate",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.4/group-translate.zip#sha256=59af210cd868cbcd649dc1b11327b2ec92faf7bbcb1ade8635dbebf365a2a97c",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/group-translate-v1.3.5/group-translate.zip#sha256=2b2d80c8703cee9e8658d1810234318396e6da1036bb3599477475aac91d40a4",
     "permissions": [
       "messages:send",
       "engine:read",
@@ -1156,7 +1156,7 @@
   {
     "id": "gsheets-logger",
     "name": "Google Sheets Logger",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "type": "extension",
     "status": "stable",
     "description": "Logs WhatsApp message events to a Google Sheet via a service account.",
@@ -1171,12 +1171,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "gsheets-logger",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/gsheets-logger",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.6/gsheets-logger.zip#sha256=4e5878093e7b1e0a8a6478e06088928188e08060a8cdd484f9639784afa9833a",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/gsheets-logger-v0.3.7/gsheets-logger.zip#sha256=31936f8d805eaf19b62ed93227f1af39829c4afff79d551eb907870fed14ddb7",
     "permissions": [
       "net:fetch",
       "storage:use"
@@ -1363,7 +1363,7 @@
   {
     "id": "http-action",
     "name": "HTTP Action Bot",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "type": "extension",
     "status": "stable",
     "description": "Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat.",
@@ -1378,12 +1378,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "http-action",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/http-action",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.5/http-action.zip#sha256=691e8ade89982afd4bf0f8e74428dd5b2c55ed3da270c8cab41dba2654cc8660",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/http-action-v0.2.6/http-action.zip#sha256=650634f8acd20b4a2f0391b078b071f6512f3308d75d43a8341c0764bbcb4da5",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -1643,7 +1643,7 @@
   {
     "id": "supabase-otp-hook",
     "name": "Supabase Auth OTP",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "type": "extension",
     "status": "beta",
     "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -1660,12 +1660,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.16",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "supabase-otp-hook",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.3/supabase-otp-hook.zip#sha256=ade0e7146a3edc232b9b84e582750cb6a62da3b4d90e1586a2f3e5ba759f73e1",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/supabase-otp-hook-v0.3.4/supabase-otp-hook.zip#sha256=827be1d02d8578dda21ca37c10ae14bb38a165472375c845639d0cf4bcd5cc48",
     "permissions": [
       "webhook:ingress",
       "messages:send"
@@ -1828,7 +1828,7 @@
   {
     "id": "typebot-connector",
     "name": "Typebot Connector",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "type": "extension",
     "status": "stable",
     "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -1845,12 +1845,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.8.2",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "typebot-connector",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.5/typebot-connector.zip#sha256=1107e5dc59c1ecf6a7624b583d0f4b14259a8c41be3a6b943742af0854a9a5a0",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/typebot-connector-v0.2.6/typebot-connector.zip#sha256=5c7cf5a87bed497f01593a9cd2f02e13adbba18b8bd6c79f198da5f9db2cb5fb",
     "permissions": [
       "net:fetch",
       "conversation:send",
@@ -2087,7 +2087,7 @@
   {
     "id": "voice-transcription",
     "name": "Voice Note Transcription",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "type": "extension",
     "status": "beta",
     "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook — so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -2104,12 +2104,12 @@
       "openwa"
     ],
     "minOpenWAVersion": "0.7.0",
-    "testedOpenWAVersion": "0.22.0",
-    "releasedAt": "2026-08-19",
+    "testedOpenWAVersion": "0.23.0",
+    "releasedAt": "2026-08-20",
     "repoPath": "voice-transcription",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.6/voice-transcription.zip#sha256=d6b1465ed5940026df58f47332842a66232210f58f2f1e04dd1ffaf2e72bf503",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/voice-transcription-v1.2.7/voice-transcription.zip#sha256=ac4c051c5ccca96a2c9685a6dfa28a3aee700c43a7befa7143ae0a7281fd39ca",
     "permissions": [
       "net:fetch",
       "messages:send",

--- a/supabase-otp-hook/CHANGELOG.md
+++ b/supabase-otp-hook/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.3.3] - 2026-08-19
 
 ### Fixed

--- a/supabase-otp-hook/README.md
+++ b/supabase-otp-hook/README.md
@@ -15,13 +15,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `supabase-otp-hook` |
-| **Version** | 0.3.3 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.3.4 |
+| **Released** | 2026-08-20 |
 | **Status** | beta |
 | **Author** | maplerichie |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.16 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.8.16 (tested 0.23.0) |
 | **Keywords** | supabase, auth, otp, sms, whatsapp, verification, standard-webhooks, openwa |
 | **Repository** | [OpenWA-plugins/supabase-otp-hook](https://github.com/rmyndharis/OpenWA-plugins/tree/main/supabase-otp-hook) |
 <!-- END DETAILS -->

--- a/supabase-otp-hook/manifest.json
+++ b/supabase-otp-hook/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "supabase-otp-hook",
   "name": "Supabase Auth OTP",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Deliver Supabase Auth phone OTPs over WhatsApp.",
@@ -12,7 +12,7 @@
   "keywords": ["supabase", "auth", "otp", "sms", "whatsapp", "verification", "standard-webhooks", "openwa"],
   "status": "beta",
   "minOpenWAVersion": "0.8.16",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "sdkVersion": "1",
   "permissions": ["webhook:ingress", "messages:send"],
   "sessionScoped": true,

--- a/typebot-connector/CHANGELOG.md
+++ b/typebot-connector/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Typebot Connector plugin are documented here. The for
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [0.2.5] - 2026-08-19
 
 ### Changed

--- a/typebot-connector/README.md
+++ b/typebot-connector/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `typebot-connector` |
-| **Version** | 0.2.5 |
-| **Released** | 2026-08-19 |
+| **Version** | 0.2.6 |
+| **Released** | 2026-08-20 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.8.2 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.8.2 (tested 0.23.0) |
 | **Keywords** | typebot, chatbot, flow, bot, no-code, two-way, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/typebot-connector](https://github.com/rmyndharis/OpenWA-plugins/tree/main/typebot-connector) |
 <!-- END DETAILS -->

--- a/typebot-connector/manifest.json
+++ b/typebot-connector/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "typebot-connector",
   "name": "Typebot Connector",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Runs a Typebot flow as the brain of a WhatsApp bot: inbound messages drive a Typebot chat session via the live Chat API, and the bot's replies — text, media, and numbered-choice inputs — are sent back to WhatsApp. Auto-starts every chat, handles file-upload steps, and resets when the flow ends or after an idle timeout. Runs sandboxed in the plugin worker; no public URL or webhook required.",
@@ -12,7 +12,7 @@
   "keywords": ["typebot", "chatbot", "flow", "bot", "no-code", "two-way", "whatsapp", "openwa"],
   "status": "stable",
   "minOpenWAVersion": "0.8.2",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "sdkVersion": "1",
   "permissions": ["net:fetch", "conversation:send",
     "storage:use"],

--- a/voice-transcription/CHANGELOG.md
+++ b/voice-transcription/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Voice Note Transcription plugin are documented here. 
 
 ## [Unreleased]
 
+## [1.2.7] - 2026-08-20
+
+### Changed
+
+- **Verified against OpenWA v0.23.0** (testedOpenWAVersion 0.22.0 → 0.23.0).
+
 ## [1.2.6] - 2026-08-19
 
 ### Changed

--- a/voice-transcription/README.md
+++ b/voice-transcription/README.md
@@ -14,13 +14,13 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `voice-transcription` |
-| **Version** | 1.2.6 |
-| **Released** | 2026-08-19 |
+| **Version** | 1.2.7 |
+| **Released** | 2026-08-20 |
 | **Status** | beta |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
 | **Type** | `extension` |
-| **Requires OpenWA** | ≥ 0.7.0 (tested 0.22.0) |
+| **Requires OpenWA** | ≥ 0.7.0 (tested 0.23.0) |
 | **Keywords** | transcription, speech-to-text, stt, whisper, voice, audio, whatsapp, openwa |
 | **Repository** | [OpenWA-plugins/voice-transcription](https://github.com/rmyndharis/OpenWA-plugins/tree/main/voice-transcription) |
 <!-- END DETAILS -->

--- a/voice-transcription/manifest.json
+++ b/voice-transcription/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-transcription",
   "name": "Voice Note Transcription",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Transcribes inbound WhatsApp voice notes to text via an OpenAI-compatible speech-to-text backend (self-hosted Speaches/faster-whisper or hosted Groq/OpenAI) and delivers a `message.transcription` event to your webhook \u2014 so bots and AI can read and reply to audio. Off the message-delivery path; disabled until enabled.",
@@ -21,7 +21,7 @@
   ],
   "status": "beta",
   "minOpenWAVersion": "0.7.0",
-  "testedOpenWAVersion": "0.22.0",
+  "testedOpenWAVersion": "0.23.0",
   "provides": [
     "transcription"
   ],


### PR DESCRIPTION
OpenWA 0.23.0 shipped without touching the plugin runtime: `src/core/plugins`, `src/core/hooks` and `src/modules/plugins` are unchanged from v0.22.0, and the only engine-interface movement since the v0.20.0 vendored-types alignment is optional trailing parameters (`mentions` on `replyToMessage`/`editMessage`, `messageIds` on `sendSeen`). None of it is on a path any plugin calls, so this carries code changes for no plugin: each cuts a patch release whose only content is `testedOpenWAVersion` 0.23.0.

- Bumped every plugin one patch version and set `testedOpenWAVersion` to 0.23.0.
- Added the verification CHANGELOG entry per plugin, dated 2026-08-20.
- Regenerated `plugins.json` and the README tables (`npm run catalog`), with new `#sha256` pins for the rebuilt archives.

Verified against a host built from source identical to the v0.23.0 tag:

- Install, config and enable for all ten plugins, all reporting healthy.
- Hook registration for every plugin matches its manifest (`message:received` et al. in the host log).
- Signed ingress for both webhook plugins: chatwoot-adapter (HMAC over `{timestamp}.{rawBody}`) answered 202 accepted, a wrong signature answered 401, and replaying the same `X-Chatwoot-Delivery` answered duplicate; supabase-otp-hook (Standard Webhooks) answered its configured `{"ok":true}` ack, 401 on a bad signature, duplicate on the same `webhook-id`.
- Uninstalled chatwoot-adapter, freshly installed the rebuilt 0.9.5 archive, re-enabled it and delivered another signed webhook through a new instance.

Gates: 587 tests pass, `tsc --noEmit` clean, loader contract and catalog check green.

after-hours 0.2.5, chat-flow 1.1.6, chatwoot-adapter 0.9.5, faq-bot 0.2.5, group-translate 1.3.5, gsheets-logger 0.3.7, http-action 0.2.6, supabase-otp-hook 0.3.4, typebot-connector 0.2.6, voice-transcription 1.2.7