### PR TITLE
fix(faq-bot): count every spelling of an adjacency run

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository provides:
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.7 | stable |
 | [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.8 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.7 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.7 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.8 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.7 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.9 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.8 | stable |

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -20,9 +20,17 @@ The version here always matches `manifest.json`'s `version`.
   `((a|b)*(a|b)*)(a|b)*$`, and the `{1}` spelling). A group with a quantifier now counts as one
   element, and a transparent group splices its body into the enclosing run. Each accepted form was
   O(n^3): measured against 140 characters, 87 ms to 407 ms, so tens of seconds at the 1000-character
-  body cap, which a running regex cannot be interrupted to honour. Two adjacent quantifiers remain
-  allowed, a mandatory atom or a `|` still breaks the chain, and groups competing for different
-  characters (`(x)*(y)*(z)*`, `(a*)(b*)(c*)`) never form a run, so ordinary rules are unaffected.
+  body cap, which a running regex cannot be interrupted to honour.
+- **Adjacency is judged on the characters an atom matches, not on how it is spelled.** The run compared
+  atoms by atom key, so `[ab]` and `[bc]` looked unrelated although both match `b`, and
+  `[ab]*[bc]*[cd]*$` was accepted while the alternation spelling of the same regex was refused. Against
+  600 characters it costs 8.9 s, and `\w*\d*\w*x` 22 s, so roughly 41 s and 103 s at the input cap.
+  A group form is now refused exactly where the same shape written with bare atoms already was, so the
+  screen's paths agree instead of the verdict turning on notation. Two adjacent quantifiers remain
+  allowed, a mandatory atom or a `|` still breaks the chain, and elements sharing no character never
+  form a run, so `a*b*c*`, `order\s+\d+`, `(x)*(y)*(z)*` and `(a*)(b*)(c*)` are unaffected. A rule of
+  the widened shape, such as `.*(word)*.*`, is dropped with a warning at enable, so re-check the log
+  after upgrading.
 
 ## [0.2.7] - 2026-09-05
 

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -12,13 +12,17 @@ The version here always matches `manifest.json`'s `version`.
 
 ### Fixed
 
-- **A group carrying an unbounded quantifier now counts toward the adjacent-quantifier limit, as a
-  bare atom always has.** The screen refused `.*.*.*done` but accepted `(a|b)*(a|b)*(a|b)*$`, the
-  same shape written with groups, because a group restored the run parked when it opened instead of
-  joining it. An accepted pattern of that shape is O(n^3): 380 ms against 150 characters, and roughly
-  113 s at the 1000-character body cap, which a running regex cannot be interrupted to honour. Two
-  adjacent quantifiers remain allowed, and groups competing for different characters (`(x)*(y)*(z)*`)
-  never form a run, so ordinary rules are unaffected.
+- **Parentheses no longer hide a run of adjacent unbounded quantifiers from the regex screen.** The
+  screen refused `.*.*.*done` but accepted every grouped spelling of the same shape, because the
+  adjacency run was parked at `(` and restored at `)`, so both the group itself and whatever its body
+  ended with were discarded. Two forms escaped: a group carrying the quantifier
+  (`(a|b)*(a|b)*(a|b)*$`), and a transparent group around one (`(a*)(a*)(a*)$`,
+  `((a|b)*(a|b)*)(a|b)*$`, and the `{1}` spelling). A group with a quantifier now counts as one
+  element, and a transparent group splices its body into the enclosing run. Each accepted form was
+  O(n^3): measured against 140 characters, 87 ms to 407 ms, so tens of seconds at the 1000-character
+  body cap, which a running regex cannot be interrupted to honour. Two adjacent quantifiers remain
+  allowed, a mandatory atom or a `|` still breaks the chain, and groups competing for different
+  characters (`(x)*(y)*(z)*`, `(a*)(b*)(c*)`) never form a run, so ordinary rules are unaffected.
 
 ## [0.2.7] - 2026-09-05
 

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,18 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-09-05
+
+### Fixed
+
+- **A group carrying an unbounded quantifier now counts toward the adjacent-quantifier limit, as a
+  bare atom always has.** The screen refused `.*.*.*done` but accepted `(a|b)*(a|b)*(a|b)*$`, the
+  same shape written with groups, because a group restored the run parked when it opened instead of
+  joining it. An accepted pattern of that shape is O(n^3): 380 ms against 150 characters, and roughly
+  113 s at the 1000-character body cap, which a running regex cannot be interrupted to honour. Two
+  adjacent quantifiers remain allowed, and groups competing for different characters (`(x)*(y)*(z)*`)
+  never form a run, so ordinary rules are unaffected.
+
 ## [0.2.7] - 2026-09-05
 
 ### Fixed

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -31,6 +31,15 @@ The version here always matches `manifest.json`'s `version`.
   form a run, so `a*b*c*`, `order\s+\d+`, `(x)*(y)*(z)*` and `(a*)(b*)(c*)` are unaffected. A rule of
   the widened shape, such as `.*(word)*.*`, is dropped with a warning at enable, so re-check the log
   after upgrading.
+- **The screen no longer depends on the alphabet, or on how an escape is written.** Its character scan
+  covers printable ASCII only, so a class of CJK, Arabic or accented Latin characters was seen as
+  matching nothing and a chain of three read as non-competing: `[\u4e00-\u9fff]*` repeated three times
+  cost ~85 s at the input cap. Identical spellings are now always treated as competing, which is what
+  the screen did before this release and what covers those. Separately, a fixed-length escape
+  (`\x61`, `\u0061`, `\u{1F600}`, `\cJ`, `\p{L}`) is now one atom rather than a backslash pair
+  followed by stray characters, and a named group `(?<name>...)` has its name skipped instead of walked
+  as atoms; both mis-readings inserted fake mandatory atoms that broke the run, letting the same shapes
+  through at ~35 s to ~46 s.
 
 ## [0.2.7] - 2026-09-05
 

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -112,7 +112,7 @@ rule sets.
 `regex` patterns are operator-authored (trusted) and tested against at most the first 1000 characters
 of a message. At parse time every pattern is screened for catastrophic-backtracking shapes — nested,
 adjacent-overlapping, and repeated-variable-width quantifiers (e.g. `(a+)+`, `.*.*.*`,
-`(a|b)*(a|b)*(a|b)*`, `(a*)(a*)(a*)`, `(a?){40}`), plus
+`(a|b)*(a|b)*(a|b)*`, `(a*)(a*)(a*)`, `[ab]*[bc]*[cd]*`, `(a?){40}`), plus
 ambiguous repeated alternations (`(a|a)*`, `(a|ab)+`, `^([a-z]|[a-z0-9])+$`, `^(\w|\d)+$`) — and an
 unsafe one is skipped with a warning. This parse-time screen is the real safeguard: the sandbox hook
 timeout lets the host proceed but cannot interrupt a synchronous regex already running in the plugin

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,7 +14,7 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.7 |
+| **Version** | 0.2.8 |
 | **Released** | 2026-09-05 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
@@ -111,7 +111,8 @@ rule sets.
 
 `regex` patterns are operator-authored (trusted) and tested against at most the first 1000 characters
 of a message. At parse time every pattern is screened for catastrophic-backtracking shapes — nested,
-adjacent-overlapping, and repeated-variable-width quantifiers (e.g. `(a+)+`, `.*.*.*`, `(a?){40}`), plus
+adjacent-overlapping, and repeated-variable-width quantifiers (e.g. `(a+)+`, `.*.*.*`,
+`(a|b)*(a|b)*(a|b)*`, `(a?){40}`), plus
 ambiguous repeated alternations (`(a|a)*`, `(a|ab)+`, `^([a-z]|[a-z0-9])+$`, `^(\w|\d)+$`) — and an
 unsafe one is skipped with a warning. This parse-time screen is the real safeguard: the sandbox hook
 timeout lets the host proceed but cannot interrupt a synchronous regex already running in the plugin

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -112,7 +112,7 @@ rule sets.
 `regex` patterns are operator-authored (trusted) and tested against at most the first 1000 characters
 of a message. At parse time every pattern is screened for catastrophic-backtracking shapes — nested,
 adjacent-overlapping, and repeated-variable-width quantifiers (e.g. `(a+)+`, `.*.*.*`,
-`(a|b)*(a|b)*(a|b)*`, `(a?){40}`), plus
+`(a|b)*(a|b)*(a|b)*`, `(a*)(a*)(a*)`, `(a?){40}`), plus
 ambiguous repeated alternations (`(a|a)*`, `(a|ab)+`, `^([a-z]|[a-z0-9])+$`, `^(\w|\d)+$`) — and an
 unsafe one is skipped with a warning. This parse-time screen is the real safeguard: the sandbox hook
 timeout lets the host proceed but cannot interrupt a synchronous regex already running in the plugin

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -108,6 +108,27 @@ test('parseRules rejects 3+ adjacent overlapping unbounded quantifiers (sibling 
   assert.deepEqual(skipped, ['.*.*.*done', '\\w*\\w*\\w*\\w*\\w*!']);
 });
 
+test('an unbounded-quantified GROUP counts toward the adjacency run, like an atom', () => {
+  // Rule 2 only ever tracked bare atoms, so `.*.*.*done` was refused while the same shape written with
+  // groups sailed through: a group restored the run parked when it opened instead of joining it.
+  // Measured on the real engine, `(a|b)*(a|b)*(a|b)*$` takes 380 ms against 150 characters and is
+  // O(n^3), i.e. ~113 s at the 1000-character body cap, which a regex cannot be interrupted to honour.
+  for (const pattern of [
+    '(a|b)*(a|b)*(a|b)*$',
+    '(a)*(a)*(a)*$',
+    '(a|b)+(a|b)+(a|b)+$',
+    '(\\w)*(\\w)*(\\w)*!',
+    '.*(a|b)*.*x', // mixed: a group between two wildcards is still three in a row
+  ]) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // Two adjacent is O(n^2) and stays allowed, exactly as for atoms, and groups that compete for
+  // DIFFERENT characters never form a run however many of them there are.
+  for (const pattern of ['(a|b)*(a|b)*$', '(x)*(y)*(z)*$', '(ab)*(cd)*(ef)*$']) {
+    assert.equal(isSafeRegexPattern(pattern), true, `should accept: ${pattern}`);
+  }
+});
+
 test('parseRules allows two adjacent overlapping quantifiers (O(n^2) is safe under the 1000-char cap)', () => {
   const { skipped } = parseRules(
     JSON.stringify([

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -129,6 +129,22 @@ test('an unbounded-quantified GROUP counts toward the adjacency run, like an ato
   }
 });
 
+test('adjacency is judged on the characters an atom matches, not on how it is spelled', () => {
+  // The run used to compare atoms by atom KEY (equal keys, or `.`), which is a different question from
+  // "can these compete for the same character". `[ab]` and `[bc]` are different keys and both match
+  // `b`, so a chain of overlapping classes read as three non-competing quantifiers. Measured against
+  // 600 characters chosen to match every class and fail at the end, then O(n^3) to the 1000-char cap:
+  // `[ab]*[bc]*[cd]*$` 8.9 s (~41 s), `\\w*\\d*\\w*x` 22 s (~103 s), `[a-z]*[a-z0-9]*[a-z]*z` 25 s (~117 s).
+  // The alternation spelling of the same regex was already refused, so the verdict turned on notation.
+  for (const pattern of ['[ab]*[bc]*[cd]*$', '\\w*\\d*\\w*x', '\\d*\\w*\\d*y', '[a-z]*[a-z0-9]*[a-z]*z']) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // Classes that share no character still never form a run, which is what keeps ordinary rules alive.
+  for (const pattern of ['a*b*c*', 'order\\s+\\d+', '\\s*\\d+', '[^0-9]*x', '\\d{3}-\\d{4}']) {
+    assert.equal(isSafeRegexPattern(pattern), true, `should accept: ${pattern}`);
+  }
+});
+
 test('a transparent group splices its body into the run instead of hiding it', () => {
   // Parentheses that carry no quantifier are not a boundary, they are punctuation: `(a*)(a*)(a*)` is
   // `a*a*a*` with three pairs of them. The run was PARKED at `(` and RESTORED at `)`, so whatever the

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -145,6 +145,43 @@ test('adjacency is judged on the characters an atom matches, not on how it is sp
   }
 });
 
+test('adjacency sees characters outside printable ASCII, and the walker parses the escapes that carry them', () => {
+  // firstCharSet only scans printable ASCII, so a class of CJK, Arabic or accented Latin characters
+  // comes back EMPTY, and an empty set intersects nothing. Comparing spellings for equality is what
+  // catches those, and it is why that check is not an optimisation: without it each of these reads as
+  // three non-competing quantifiers. Measured against 250 characters that all match, failing on the
+  // last, then O(n^3) to the cap: 0.9 s to 1.3 s, i.e. 57 s to 85 s at 1000 characters. This is the
+  // traffic the plugin actually serves, so it must not depend on the alphabet.
+  for (const pattern of [
+    '[\\u4e00-\\u9fff]*[\\u4e00-\\u9fff]*[\\u4e00-\\u9fff]*$',
+    '[\\u0600-\\u06ff]*[\\u0600-\\u06ff]*[\\u0600-\\u06ff]*$',
+    '[\\u00e0-\\u00ff]*[\\u00e0-\\u00ff]*[\\u00e0-\\u00ff]*$',
+    // Fixed-length escapes are one atom. Read as `\\x` + `6` + `1`, the stray digits looked like
+    // mandatory atoms and broke the run, so these escaped at ~35 s to ~41 s at the cap.
+    '\\x61*\\x61*\\x61*$',
+    '\\u0061*\\u0061*\\u0061*$',
+    '\\cJ*\\cJ*\\cJ*$',
+    // A named group is not a lookbehind: its NAME has to be skipped, or its letters walk as atoms.
+    '(?<n>a*)(?<m>a*)(?<o>a*)$',
+  ]) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // Unseen is not the same as competing. A CJK class and `\\s` genuinely do not overlap, and refusing
+  // that pair would break an ordinary rule for exactly the operators this matters most to.
+  for (const pattern of [
+    '[\\u4e00-\\u9fff]*\\s*[\\u4e00-\\u9fff]*',
+    '[\\u4e00-\\u9fff]+',
+    '^[\\u4e00-\\u9fff]{2,}$',
+    '^(你好|您好)$',
+    '[àéîõü]+',
+    '(?<=a)b',
+    '(?<!a)b',
+    '(?<n>a)+',
+  ]) {
+    assert.equal(isSafeRegexPattern(pattern), true, `should accept: ${pattern}`);
+  }
+});
+
 test('a transparent group splices its body into the run instead of hiding it', () => {
   // Parentheses that carry no quantifier are not a boundary, they are punctuation: `(a*)(a*)(a*)` is
   // `a*a*a*` with three pairs of them. The run was PARKED at `(` and RESTORED at `)`, so whatever the

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -129,6 +129,33 @@ test('an unbounded-quantified GROUP counts toward the adjacency run, like an ato
   }
 });
 
+test('a transparent group splices its body into the run instead of hiding it', () => {
+  // Parentheses that carry no quantifier are not a boundary, they are punctuation: `(a*)(a*)(a*)` is
+  // `a*a*a*` with three pairs of them. The run was PARKED at `(` and RESTORED at `)`, so whatever the
+  // body ended with was discarded and the same shape escaped however it was grouped. Measured against
+  // 140 characters and O(n^3) from there: `(a*)(a*)(a*)$` 87 ms, `((a|b)*(a|b)*)(a|b)*$` 334 ms,
+  // `(a*){1}(a*){1}(a*){1}$` 407 ms, i.e. tens of seconds at the 1000-character body cap.
+  for (const pattern of [
+    '(a*)(a*)(a*)$',
+    '(a)*(a)*(a)*$',
+    '((a|b)*(a|b)*)(a|b)*$',
+    '(a|b)*((a|b)*(a|b)*)$',
+    '((a|b)*(a|b)*(a|b)*)$',
+    '(.*)(.*)(.*)x',
+    '(a*){1}(a*){1}(a*){1}$', // `{1}` is transparent too
+  ]) {
+    assert.equal(isSafeRegexPattern(pattern), false, `should reject: ${pattern}`);
+  }
+  // Splicing must not invent a run where none exists. A mandatory atom between the groups breaks the
+  // chain, disjoint bodies never form one, and a group with nothing unbounded in it is untouched.
+  for (const pattern of ['(a*)(b*)(c*)', '(a*)x(a*)x(a*)', '(a*)', '((a*))', 'x*(y?)z*w*', '.*(x).*(y).*!']) {
+    assert.equal(isSafeRegexPattern(pattern), true, `should accept: ${pattern}`);
+    const started = Date.now();
+    new RegExp(pattern, 'i').test('a'.repeat(1000));
+    assert.ok(Date.now() - started < 200, `${pattern} is slow at the input cap`);
+  }
+});
+
 test('parseRules allows two adjacent overlapping quantifiers (O(n^2) is safe under the 1000-char cap)', () => {
   const { skipped } = parseRules(
     JSON.stringify([

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -65,6 +65,54 @@ function quantifierAt(
 
 const overlaps = (a: string, b: string): boolean => a === 'ANY' || b === 'ANY' || a === b;
 
+/**
+ * One element of a rule-2 adjacency run: a bare atom, or an unbounded-quantified GROUP.
+ *
+ * A group has to be carried differently from an atom because it has no single atom key: `(a|b)*` can
+ * start with either branch, so it is represented by the characters its body can begin with, unioned
+ * over the branches (null = could not be decided, treated as overlapping).
+ */
+type RunElement = { kind: 'atom'; key: string } | { kind: 'group'; chars: Set<string> | null };
+
+/**
+ * The characters ANY branch of a group can start with, or null when that cannot be decided.
+ *
+ * Unioned rather than intersected: the group is entered afresh on every repetition, so it competes for
+ * a character as soon as ONE branch can begin with it. A branch whose first atom is unknown (it opens
+ * with a nested group) makes the whole set undecidable, which fails closed.
+ */
+function branchFirstChars(branches: Branch[]): Set<string> | null {
+  const out = new Set<string>();
+  for (const b of branches) {
+    if (b.first === null) return null;
+    const set = firstCharSet(b.first);
+    if (set === null) return null;
+    for (const ch of set) out.add(ch);
+  }
+  return out.size > 0 ? out : null;
+}
+
+/** The characters a run element can start with, or null when that cannot be decided. */
+function runChars(e: RunElement): Set<string> | null {
+  return e.kind === 'atom' ? firstCharSet(e.key) : e.chars;
+}
+
+/**
+ * Do two adjacent unbounded-quantified elements compete for the same characters?
+ *
+ * Two ATOMS are compared exactly as before, by atom key, so no pattern that passed this screen on the
+ * atom path changes verdict. A group on either side falls back to comparing character sets, which is
+ * the only comparison available for something with no single key; an undecidable set fails closed.
+ */
+function runOverlaps(a: RunElement, b: RunElement): boolean {
+  if (a.kind === 'atom' && b.kind === 'atom') return overlaps(a.key, b.key);
+  const sa = runChars(a);
+  const sb = runChars(b);
+  if (sa === null || sb === null) return true;
+  for (const ch of sa) if (sb.has(ch)) return true;
+  return false;
+}
+
 /** Turn an atom key back into a regex source safe to compile on its own. */
 function atomSource(key: string): string {
   if (key.startsWith('\\') || key.startsWith('[')) return key;
@@ -138,9 +186,11 @@ const REPEAT_THRESHOLD = 10;
 /**
  * Conservatively reject patterns prone to catastrophic backtracking. Four classes are closed:
  *  1. an unbounded quantifier on a group that itself contains one — `(a+)+`, `((a+))+`, `(\w+\s?)*`;
- *  2. THREE OR MORE adjacent unbounded quantifiers over overlapping atoms in one concatenation —
- *     `.*.*.*`, `\w*\w*\w*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only O(n^2), safe under the
- *     1000-char input cap, so it is allowed; a mandatory atom or a group boundary breaks the chain;
+ *  2. THREE OR MORE adjacent unbounded quantifiers over overlapping elements in one concatenation —
+ *     `.*.*.*`, `\w*\w*\w*`, `(a|b)*(a|b)*(a|b)*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only
+ *     O(n^2), safe under the 1000-char input cap, so it is allowed; a mandatory atom breaks the chain.
+ *     An element is a bare atom OR an unbounded-quantified group: counting only atoms left the group
+ *     form of the same shape accepted, at ~113 s on a 1000-character input;
  *  3. an unbounded or ≥REPEAT_THRESHOLD repeat of a group whose body has a variable-width quantifier —
  *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat of a VARIABLE body like `(ab?){2}` is
  *     allowed, but any repeat of an UNBOUNDED body is not — see (1).
@@ -174,14 +224,14 @@ export function isSafeRegexPattern(p: string): boolean {
     hasAmbiguous: boolean;
     // Whether this group contributed an atom of its own, i.e. anything besides the nested group(s).
     sawAtom: boolean;
-    savedPrev: string | null;
+    savedPrev: RunElement | null;
     savedRun: number;
     // One record per top-level branch of THIS group; see Branch.
     branches: Branch[];
   }[] = [];
-  // Rule 2 state: the key of the previous unbounded-quantified atom in the current flat concatenation,
-  // or null after a mandatory atom / `|` / group boundary (which break adjacency).
-  let prevUnbounded: string | null = null;
+  // Rule 2 state: the previous unbounded-quantified element in the current flat concatenation, or null
+  // after a mandatory atom / `|` / group boundary (which break adjacency).
+  let prevUnbounded: RunElement | null = null;
   let adjacentRun = 0; // length of the current run of adjacent overlapping unbounded-quantified atoms
   let i = 0;
   while (i < p.length) {
@@ -247,9 +297,30 @@ export function isSafeRegexPattern(p: string): boolean {
         if (q.variable || frame.hasVariable) stack[stack.length - 1].hasVariable = true;
         if (ambiguous) stack[stack.length - 1].hasAmbiguous = true;
       }
+      // An UNBOUNDED-quantified group is itself a run element, exactly like an unbounded-quantified
+      // atom. Restoring the parked run here instead (which is what a nullable group did) meant rule 2
+      // only ever counted bare atoms, so `.*.*.*done` was refused while `(a|b)*(a|b)*(a|b)*$` was
+      // accepted and then ran O(n^3): 162 ms at 120 characters, and ~90 s at the 1000-character body
+      // cap, which a regex cannot be interrupted to honour.
+      if (q.unbounded) {
+        const here: RunElement = { kind: 'group', chars: branchFirstChars(frame.branches) };
+        // Compared against the run PARKED when this group opened, not the live one: `(` resets
+        // prevUnbounded so the body starts its own concatenation, so the live value here belongs to
+        // the group's last inner atom and says nothing about what precedes the group.
+        let run = frame.savedRun;
+        if (frame.savedPrev !== null && runOverlaps(frame.savedPrev, here)) {
+          if (++run >= 3) return false; // (2) 3+ adjacent overlapping unbounded quantifiers
+        } else {
+          run = 1;
+        }
+        adjacentRun = run;
+        prevUnbounded = here;
+        i += 1 + q.len;
+        continue;
+      }
       // A group breaks flat adjacency only if it MUST consume something. `(x?)` can match empty, so
       // `.*(x?).*` is `.*.*` in disguise; resume the parked run rather than pretending it ended.
-      const nullable = frame.hasVariable || q.unbounded || (q.present && q.min === 0);
+      const nullable = frame.hasVariable || (q.present && q.min === 0);
       if (nullable) { prevUnbounded = frame.savedPrev; adjacentRun = frame.savedRun; }
       else { prevUnbounded = null; adjacentRun = 0; }
       i += 1 + q.len;
@@ -273,12 +344,13 @@ export function isSafeRegexPattern(p: string): boolean {
     if (stack.length && q.variable) stack[stack.length - 1].hasVariable = true;
     if (q.unbounded) {
       if (stack.length) stack[stack.length - 1].hasUnbounded = true;
-      if (prevUnbounded !== null && overlaps(prevUnbounded, atom.key)) {
+      const here: RunElement = { kind: 'atom', key: atom.key };
+      if (prevUnbounded !== null && runOverlaps(prevUnbounded, here)) {
         if (++adjacentRun >= 3) return false; // (2) 3+ adjacent overlapping unbounded quantifiers
       } else {
         adjacentRun = 1;
       }
-      prevUnbounded = atom.key;
+      prevUnbounded = here;
     } else if (!q.present || q.min >= 1) {
       prevUnbounded = null; adjacentRun = 0; // a mandatory (non-skippable) atom breaks adjacency
     }

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -63,8 +63,6 @@ function quantifierAt(
   return none;
 }
 
-const overlaps = (a: string, b: string): boolean => a === 'ANY' || b === 'ANY' || a === b;
-
 /**
  * One element of a rule-2 adjacency run: a bare atom, or an unbounded-quantified GROUP.
  *
@@ -100,12 +98,17 @@ function runChars(e: RunElement): Set<string> | null {
 /**
  * Do two adjacent unbounded-quantified elements compete for the same characters?
  *
- * Two ATOMS are compared exactly as before, by atom key, so no pattern that passed this screen on the
- * atom path changes verdict. A group on either side falls back to comparing character sets, which is
- * the only comparison available for something with no single key; an undecidable set fails closed.
+ * Compared by the characters each can START with, for atoms and groups alike. Atoms used to be
+ * compared by atom KEY instead (equal keys, or `.`), which is not the same question: `[ab]` and `[bc]`
+ * are different keys and both match `b`, so `[ab]*[bc]*[cd]*$` was read as three non-competing
+ * quantifiers and accepted, at 8.9 s against 600 characters and ~41 s at the input cap. `\w*\d*\w*x`
+ * (~103 s) and `[a-z]*[a-z0-9]*[a-z]*z` (~117 s) escaped the same way. The alternation spelling of the
+ * very same regex was refused, so the verdict turned on notation rather than on cost.
+ *
+ * An undecidable set (`.`, or an atom that will not compile alone) is null and counts as overlapping,
+ * which fails closed and preserves the old `ANY` behaviour.
  */
 function runOverlaps(a: RunElement, b: RunElement): boolean {
-  if (a.kind === 'atom' && b.kind === 'atom') return overlaps(a.key, b.key);
   const sa = runChars(a);
   const sb = runChars(b);
   if (sa === null || sb === null) return true;
@@ -189,10 +192,11 @@ const REPEAT_THRESHOLD = 10;
  *  2. THREE OR MORE adjacent unbounded quantifiers over overlapping elements in one concatenation —
  *     `.*.*.*`, `\w*\w*\w*`, `(a|b)*(a|b)*(a|b)*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only
  *     O(n^2), safe under the 1000-char input cap, so it is allowed; a mandatory atom or a `|` breaks
- *     the chain. An element is a bare atom OR an unbounded-quantified group, and a TRANSPARENT group
- *     (no quantifier, or `{1}`) splices its body into the enclosing run rather than hiding it, so
- *     `(a*)(a*)(a*)` and `((a|b)*(a|b)*)(a|b)*` count as three. Counting only bare atoms left every
- *     one of those accepted, at tens of seconds on a 1000-character input;
+ *     the chain. An element is a bare atom OR an unbounded-quantified group, a TRANSPARENT group (no
+ *     quantifier, or `{1}`) splices its body into the enclosing run rather than hiding it, and two
+ *     elements compete when the CHARACTERS they can start with intersect, not when they are spelled
+ *     the same. So `(a*)(a*)(a*)`, `((a|b)*(a|b)*)(a|b)*` and `[ab]*[bc]*[cd]*` all count as three.
+ *     Each of those was accepted before, at tens of seconds on a 1000-character input;
  *  3. an unbounded or ≥REPEAT_THRESHOLD repeat of a group whose body has a variable-width quantifier —
  *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat of a VARIABLE body like `(ab?){2}` is
  *     allowed, but any repeat of an UNBOUNDED body is not — see (1).
@@ -314,8 +318,11 @@ export function isSafeRegexPattern(p: string): boolean {
       // An UNBOUNDED-quantified group is itself a run element, exactly like an unbounded-quantified
       // atom. Restoring the parked run here instead (which is what a nullable group did) meant rule 2
       // only ever counted bare atoms, so `.*.*.*done` was refused while `(a|b)*(a|b)*(a|b)*$` was
-      // accepted and then ran O(n^3): 380 ms at 150 characters, and ~113 s at the 1000-character body
-      // cap, which a regex cannot be interrupted to honour.
+      // accepted and then ran O(n^3). Timings here and below are steady-state on this machine, the
+      // pattern compiled with the `i` flag parseRules uses, against an input that matches throughout
+      // and fails on the last character (the worst case, and the one a stranger can send): 380 ms at
+      // 150 characters of `a`, so tens of seconds at the 1000-character body cap, which a running
+      // regex cannot be interrupted to honour.
       if (q.unbounded) {
         const here: RunElement = { kind: 'group', chars: branchFirstChars(frame.branches) };
         // Compared against the run PARKED when this group opened, not the live one: `(` resets

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -19,7 +19,24 @@ const MAX_PATTERN_LENGTH = 1000;
  *  atom. Two atoms "overlap" when they can match a common character. */
 function atomAt(p: string, i: number): { key: string; len: number } {
   const c = p[i];
-  if (c === '\\') return { key: p.slice(i, i + 2), len: 2 };
+  if (c === '\\') {
+    // Fixed-length escapes are ONE atom. Taking only `\\` + one character left the rest as separate
+    // atoms (`\\x61` walked as `\\x`, `6`, `1`), and those fake mandatory atoms broke the adjacency
+    // run: `\\x61*\\x61*\\x61*$` was accepted and ran ~41 s at the input cap.
+    const n = p[i + 1];
+    if (n === 'x' && /^[0-9a-f]{2}$/i.test(p.slice(i + 2, i + 4))) return { key: p.slice(i, i + 4), len: 4 };
+    if (n === 'u' && p[i + 2] === '{') {
+      const close = p.indexOf('}', i + 3);
+      if (close !== -1) return { key: p.slice(i, close + 1), len: close + 1 - i };
+    }
+    if (n === 'u' && /^[0-9a-f]{4}$/i.test(p.slice(i + 2, i + 6))) return { key: p.slice(i, i + 6), len: 6 };
+    if (n === 'c' && /^[a-z]$/i.test(p[i + 2] ?? '')) return { key: p.slice(i, i + 3), len: 3 };
+    if ((n === 'p' || n === 'P') && p[i + 2] === '{') {
+      const close = p.indexOf('}', i + 3);
+      if (close !== -1) return { key: p.slice(i, close + 1), len: close + 1 - i };
+    }
+    return { key: p.slice(i, i + 2), len: 2 };
+  }
   if (c === '[') {
     let j = i + 1;
     if (p[j] === '^') j++;
@@ -105,10 +122,21 @@ function runChars(e: RunElement): Set<string> | null {
  * (~103 s) and `[a-z]*[a-z0-9]*[a-z]*z` (~117 s) escaped the same way. The alternation spelling of the
  * very same regex was refused, so the verdict turned on notation rather than on cost.
  *
- * An undecidable set (`.`, or an atom that will not compile alone) is null and counts as overlapping,
- * which fails closed and preserves the old `ANY` behaviour.
+ * Two elements spelled IDENTICALLY always compete, which is exact and skips the scan.
+ *
+ * That identity check is load-bearing, not an optimisation. firstCharSet only scans printable ASCII,
+ * so a class of CJK, Arabic or accented Latin characters comes back EMPTY, and an empty set intersects
+ * nothing: without the identity check `[\u4e00-\u9fff]*[\u4e00-\u9fff]*[\u4e00-\u9fff]*$` reads as
+ * three non-competing quantifiers and runs ~85 s on a 1000-character message, which is exactly the
+ * traffic this plugin serves. Key equality is what the screen used for atoms before, so this keeps that
+ * verdict exactly and adds the character comparison on top of it.
+ *
+ * A `null` set (`.`, or an atom that will not compile alone) is undecidable and fails closed. An empty
+ * one deliberately does NOT: `[\u4e00-\u9fff]*\s*[\u4e00-\u9fff]*` is a real rule, its classes
+ * genuinely do not compete, and treating unseen as competing refused it.
  */
 function runOverlaps(a: RunElement, b: RunElement): boolean {
+  if (a.kind === 'atom' && b.kind === 'atom' && a.key === b.key) return true;
   const sa = runChars(a);
   const sb = runChars(b);
   if (sa === null || sb === null) return true;
@@ -277,7 +305,20 @@ export function isSafeRegexPattern(p: string): boolean {
       });
       prevUnbounded = null; adjacentRun = 0; leadElement = null; unbroken = true;
       i++;
-      if (p[i] === '?') { i++; if (p[i] === '<') i++; if (p[i] === ':' || p[i] === '=' || p[i] === '!') i++; }
+      if (p[i] === '?') {
+        i++;
+        if (p[i] === '<' && p[i + 1] !== '=' && p[i + 1] !== '!') {
+          // Named group `(?<name>`. Only lookbehind (`(?<=`, `(?<!`) continues below; a NAME has to be
+          // skipped up to its `>`, or its letters are walked as ordinary atoms. Those fake mandatory
+          // atoms then break the adjacency run, which is how `(?<n>a*)(?<m>a*)(?<o>a*)$` was accepted
+          // and ran ~46 s at the input cap.
+          const close = p.indexOf('>', i);
+          i = close === -1 ? p.length : close + 1;
+        } else {
+          if (p[i] === '<') i++;
+          if (p[i] === ':' || p[i] === '=' || p[i] === '!') i++;
+        }
+      }
       continue;
     }
     if (c === ')') {

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -188,9 +188,11 @@ const REPEAT_THRESHOLD = 10;
  *  1. an unbounded quantifier on a group that itself contains one — `(a+)+`, `((a+))+`, `(\w+\s?)*`;
  *  2. THREE OR MORE adjacent unbounded quantifiers over overlapping elements in one concatenation —
  *     `.*.*.*`, `\w*\w*\w*`, `(a|b)*(a|b)*(a|b)*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only
- *     O(n^2), safe under the 1000-char input cap, so it is allowed; a mandatory atom breaks the chain.
- *     An element is a bare atom OR an unbounded-quantified group: counting only atoms left the group
- *     form of the same shape accepted, at ~113 s on a 1000-character input;
+ *     O(n^2), safe under the 1000-char input cap, so it is allowed; a mandatory atom or a `|` breaks
+ *     the chain. An element is a bare atom OR an unbounded-quantified group, and a TRANSPARENT group
+ *     (no quantifier, or `{1}`) splices its body into the enclosing run rather than hiding it, so
+ *     `(a*)(a*)(a*)` and `((a|b)*(a|b)*)(a|b)*` count as three. Counting only bare atoms left every
+ *     one of those accepted, at tens of seconds on a 1000-character input;
  *  3. an unbounded or ≥REPEAT_THRESHOLD repeat of a group whose body has a variable-width quantifier —
  *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat of a VARIABLE body like `(ab?){2}` is
  *     allowed, but any repeat of an UNBOUNDED body is not — see (1).
@@ -226,6 +228,10 @@ export function isSafeRegexPattern(p: string): boolean {
     sawAtom: boolean;
     savedPrev: RunElement | null;
     savedRun: number;
+    // Rule 2, transparent-group support. `savedLead` / `savedUnbroken` park the ENCLOSING
+    // concatenation's leading-run state, the way savedPrev/savedRun park its trailing state.
+    savedLead: RunElement | null;
+    savedUnbroken: boolean;
     // One record per top-level branch of THIS group; see Branch.
     branches: Branch[];
   }[] = [];
@@ -233,12 +239,19 @@ export function isSafeRegexPattern(p: string): boolean {
   // after a mandatory atom / `|` / group boundary (which break adjacency).
   let prevUnbounded: RunElement | null = null;
   let adjacentRun = 0; // length of the current run of adjacent overlapping unbounded-quantified atoms
+  // The element the CURRENT run starts at, and whether that run reaches back to the very beginning of
+  // the current concatenation. Together they let a TRANSPARENT group (no quantifier, or `{1}`) splice
+  // its body into the enclosing run instead of discarding it: `(a*)(a*)(a*)` is `a*a*a*` with three
+  // pairs of parentheses, and counting it as three is the whole point of rule 2.
+  let leadElement: RunElement | null = null;
+  let unbroken = true;
   let i = 0;
   while (i < p.length) {
     const c = p[i];
 
     if (c === '|') {
-      prevUnbounded = null; adjacentRun = 0;
+      // A new branch is a new concatenation: nothing before the `|` is adjacent to anything after it.
+      prevUnbounded = null; adjacentRun = 0; leadElement = null; unbroken = false;
       if (stack.length) stack[stack.length - 1].branches.push({ literal: '', first: null });
       i++; continue;
     }
@@ -255,9 +268,10 @@ export function isSafeRegexPattern(p: string): boolean {
       stack.push({
         hasUnbounded: false, hasVariable: false, hasAmbiguous: false, sawAtom: false,
         savedPrev: prevUnbounded, savedRun: adjacentRun,
+        savedLead: leadElement, savedUnbroken: unbroken,
         branches: [{ literal: '', first: null }],
       });
-      prevUnbounded = null; adjacentRun = 0;
+      prevUnbounded = null; adjacentRun = 0; leadElement = null; unbroken = true;
       i++;
       if (p[i] === '?') { i++; if (p[i] === '<') i++; if (p[i] === ':' || p[i] === '=' || p[i] === '!') i++; }
       continue;
@@ -265,7 +279,7 @@ export function isSafeRegexPattern(p: string): boolean {
     if (c === ')') {
       const frame = stack.pop() ?? {
         hasUnbounded: false, hasVariable: false, hasAmbiguous: false, sawAtom: false,
-        savedPrev: null, savedRun: 0,
+        savedPrev: null, savedRun: 0, savedLead: null as RunElement | null, savedUnbroken: true,
         branches: [] as Branch[],
       };
       const q = quantifierAt(p, i + 1);
@@ -300,7 +314,7 @@ export function isSafeRegexPattern(p: string): boolean {
       // An UNBOUNDED-quantified group is itself a run element, exactly like an unbounded-quantified
       // atom. Restoring the parked run here instead (which is what a nullable group did) meant rule 2
       // only ever counted bare atoms, so `.*.*.*done` was refused while `(a|b)*(a|b)*(a|b)*$` was
-      // accepted and then ran O(n^3): 162 ms at 120 characters, and ~90 s at the 1000-character body
+      // accepted and then ran O(n^3): 380 ms at 150 characters, and ~113 s at the 1000-character body
       // cap, which a regex cannot be interrupted to honour.
       if (q.unbounded) {
         const here: RunElement = { kind: 'group', chars: branchFirstChars(frame.branches) };
@@ -308,21 +322,49 @@ export function isSafeRegexPattern(p: string): boolean {
         // prevUnbounded so the body starts its own concatenation, so the live value here belongs to
         // the group's last inner atom and says nothing about what precedes the group.
         let run = frame.savedRun;
+        leadElement = frame.savedLead;
+        unbroken = frame.savedUnbroken;
         if (frame.savedPrev !== null && runOverlaps(frame.savedPrev, here)) {
           if (++run >= 3) return false; // (2) 3+ adjacent overlapping unbounded quantifiers
         } else {
+          if (run > 0) unbroken = false;
           run = 1;
+          leadElement = here;
         }
         adjacentRun = run;
         prevUnbounded = here;
         i += 1 + q.len;
         continue;
       }
+      // A TRANSPARENT group (no quantifier, or `{1}`) is just parentheses: its body belongs to the
+      // enclosing concatenation. Restoring the parked run here discarded whatever the body ended with,
+      // so `a*a*a*` was refused while `(a*)(a*)(a*)` and `((a|b)*(a|b)*)(a|b)*` sailed through, at
+      // 72 ms and 285 ms against 140 characters and O(n^3) from there. Splice instead: the body's own
+      // trailing run joins the parked one when it reaches back to the body's first element AND that
+      // element competes for the same characters as what preceded the group.
+      const transparent = !q.present || (q.min === 1 && q.count === 1 && !q.variable);
+      if (transparent && leadElement !== null) {
+        const joins = unbroken && frame.savedPrev !== null && runOverlaps(frame.savedPrev, leadElement);
+        const combined = joins ? frame.savedRun + adjacentRun : adjacentRun;
+        if (combined >= 3) return false; // (2) 3+ adjacent overlapping unbounded quantifiers
+        adjacentRun = combined;
+        // `prevUnbounded` already holds the body's trailing element, which is what follows this group.
+        // The lead belongs to the enclosing concatenation once one exists there; when it does not, the
+        // body's lead becomes it, and only stays start-anchored if both sides were.
+        if (frame.savedLead !== null) { leadElement = frame.savedLead; unbroken = frame.savedUnbroken; }
+        else { unbroken = frame.savedUnbroken && unbroken; }
+        i += 1 + q.len;
+        continue;
+      }
       // A group breaks flat adjacency only if it MUST consume something. `(x?)` can match empty, so
       // `.*(x?).*` is `.*.*` in disguise; resume the parked run rather than pretending it ended.
       const nullable = frame.hasVariable || (q.present && q.min === 0);
-      if (nullable) { prevUnbounded = frame.savedPrev; adjacentRun = frame.savedRun; }
-      else { prevUnbounded = null; adjacentRun = 0; }
+      if (nullable) {
+        prevUnbounded = frame.savedPrev; adjacentRun = frame.savedRun;
+        leadElement = frame.savedLead; unbroken = frame.savedUnbroken;
+      } else {
+        prevUnbounded = null; adjacentRun = 0; leadElement = null; unbroken = false;
+      }
       i += 1 + q.len;
       continue;
     }
@@ -348,11 +390,18 @@ export function isSafeRegexPattern(p: string): boolean {
       if (prevUnbounded !== null && runOverlaps(prevUnbounded, here)) {
         if (++adjacentRun >= 3) return false; // (2) 3+ adjacent overlapping unbounded quantifiers
       } else {
+        // A new run starts here. If anything preceded it in this concatenation, the run no longer
+        // reaches back to the start, so a transparent group around it cannot splice it onto the
+        // enclosing run.
+        if (adjacentRun > 0) unbroken = false;
         adjacentRun = 1;
+        leadElement = here;
       }
       prevUnbounded = here;
     } else if (!q.present || q.min >= 1) {
-      prevUnbounded = null; adjacentRun = 0; // a mandatory (non-skippable) atom breaks adjacency
+      // A mandatory (non-skippable) atom breaks adjacency, and with it any claim that the run reaches
+      // back to the start of this concatenation.
+      prevUnbounded = null; adjacentRun = 0; leadElement = null; unbroken = false;
     }
     i += atom.len + q.len;
   }

--- a/plugins.json
+++ b/plugins.json
@@ -695,7 +695,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -715,7 +715,7 @@
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.7/faq-bot.zip#sha256=74b183dc2b884d62b33e45f906ed8412dc6b7ae33d1497af79d3f0d49a716635",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=46ac4f65a744fd24ce4c02735adf36b7cecba8ce0c0e08702e03ffc007342910",
     "permissions": [
       "messages:send"
     ],

--- a/plugins.json
+++ b/plugins.json
@@ -715,7 +715,7 @@
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=46ac4f65a744fd24ce4c02735adf36b7cecba8ce0c0e08702e03ffc007342910",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=a6d49021e16745e5a34d1dd8ef6960670da7819b6ba3b5fd046a3889f9d31f9c",
     "permissions": [
       "messages:send"
     ],

--- a/plugins.json
+++ b/plugins.json
@@ -715,7 +715,7 @@
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=5d389a46cb4708e1733c3e84cdef89da85b4d3849b66e81580e2d7acc300a17c",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=6256cd5eae3c3673bf1fc27649d69f1e84ea9f93da0916778ea54e8b1dbd0f68",
     "permissions": [
       "messages:send"
     ],

--- a/plugins.json
+++ b/plugins.json
@@ -715,7 +715,7 @@
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=a6d49021e16745e5a34d1dd8ef6960670da7819b6ba3b5fd046a3889f9d31f9c",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.8/faq-bot.zip#sha256=5d389a46cb4708e1733c3e84cdef89da85b4d3849b66e81580e2d7acc300a17c",
     "permissions": [
       "messages:send"
     ],


### PR DESCRIPTION
The regex safety screen rejects three or more adjacent unbounded quantifiers over competing elements,
because that backtracks polynomially and a running JS regex cannot be interrupted. It only ever
recognised that shape when it was written with bare ASCII atoms. Four ways of writing the same regex
escaped, each of them costing tens of seconds on a message under the 1000-character body cap.

A refused rule is dropped with a log line, so both directions of error are expensive: a false accept
stalls the worker for any stranger who sends one message, a false reject silently stops a working rule
from answering. Every change below was checked against both.

## What escaped

| Written as | Cost at the 1000-char cap |
| --- | --- |
| `(a\|b)*(a\|b)*(a\|b)*$` (the group carries the quantifier) | ~113 s |
| `(a*)(a*)(a*)$`, `((a\|b)*(a\|b)*)(a\|b)*$` (transparent parentheses) | ~26 s to ~90 s |
| `[ab]*[bc]*[cd]*$`, `\w*\d*\w*x` (competing classes, different spelling) | ~41 s to ~103 s |
| `[一-鿿]*` x3, `\x61*` x3, `(?<n>a*)` x3 (non-ASCII, escapes, named groups) | ~35 s to ~85 s |

All four are accepted on `main` today. The bare-atom spelling of each was already refused.

## The change

Rule 2 now counts an adjacency run regardless of how it is spelled:

- an unbounded-quantified **group** is a run element, carrying the characters its branches can begin
  with, since it has no single atom key;
- a **transparent** group (no quantifier, or `{1}`) splices its body into the enclosing run instead of
  discarding it, tracked with a leading-element and start-anchored flag parked per frame;
- elements compete when the **characters** they can start with intersect, not when they are spelled the
  same, so the alternation and character-class forms of one regex get one verdict;
- identical spellings always compete. This is load-bearing rather than an optimisation: the character
  scan covers printable ASCII only, so a CJK or Arabic class comes back matching nothing, and without
  it a chain of three read as harmless. It is also exactly the comparison the screen used for atoms
  before, so those verdicts are preserved rather than invented;
- a fixed-length escape (`\xHH`, `\uHHHH`, `\u{...}`, `\cX`, `\p{...}`) is one atom, and a named group
  `(?<name>...)` has its name skipped. Both mis-readings inserted fake mandatory atoms that broke the
  run.

`overlaps` had no caller left and is removed rather than kept as dead code.

## Deliberately not changed

An empty character set does **not** fail closed. A CJK class beside `\s` genuinely does not compete,
and treating unseen as competing refused that ordinary rule. `?` and `{n,m}` groups keep their existing
nullable handling; widening to them has a false-reject risk that has not been measured.

## The invariant to review against

A grouped or class-spelled form now gets the same verdict its equivalent bare-atom form already got on
`main`. Verified over 15 such pairs, including `(x(a*))(a*)(a*)$` versus `xa*a*a*$`, which cost the
same 11 ms at 252 characters.

## Verification

| Corpus | Result |
| --- | --- |
| 99 realistic operator rules, Indonesian and English | no verdict moves |
| 88 patterns, both directions | 25 refused, 63 accepted, no mismatch |
| 18 non-ASCII rules | no verdict moves |
| 15 grouped-versus-bare pairs | invariant holds |
| 34 malformed patterns | no throw, no hang |

Every timing was measured on this machine with the `i` flag `parseRules` uses, against an input that
matches throughout and fails on the last character, at 140 to 400 characters, then extrapolated by the
observed cubic order. Timings quoted in the code and CHANGELOG state the input they were taken with.

`npm run typecheck`, `npm test` (662 pass), `npm run catalog:check`, `npm run loader:check`. Each of the
four new tests fails when the corresponding part of the fix is reverted. Not verified against a running
host.

faq-bot 0.2.8.
