### PR TITLE
fix(faq-bot): bound regex matching to the first 150 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository provides:
 | [`after-hours`](./after-hours) | Auto-replies with a configurable away/closing message to messages received outside business hours. | 0.2.7 | stable |
 | [`chat-flow`](./chat-flow) | Interactive, stateful auto-reply: a trigger word starts a greeting + numbered menu, replies traverse a configurable menu tree, and per-chat state expires after 15 minutes. | 1.1.8 | stable |
 | [`chatwoot-adapter`](./chatwoot-adapter) | Two-way sync between a WhatsApp session and a Chatwoot inbox: relays WhatsApp messages (1:1 and groups, with media) into Chatwoot as an API-channel inbox, sends agent replies back to WhatsApp, and hands a chat over to a human agent — silencing other OpenWA bots — when an agent takes it in Chatwoot. First consumer of the OpenWA Integration SDK v1; runs sandboxed in the plugin worker. | 0.9.7 | stable |
-| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.9 | stable |
+| [`faq-bot`](./faq-bot) | Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules. | 0.2.10 | stable |
 | [`group-translate`](./group-translate) | Auto-translates group messages between participants' languages via a LibreTranslate backend. Configure in-chat with /tr commands. Admin-gated; disabled until enabled. | 1.3.7 | stable |
 | [`gsheets-logger`](./gsheets-logger) | Logs WhatsApp message events to a Google Sheet via a service account. | 0.3.9 | stable |
 | [`http-action`](./http-action) | Triggers safe REST API requests from WhatsApp commands and renders JSON responses back to chat. | 0.2.8 | stable |

--- a/faq-bot/CHANGELOG.md
+++ b/faq-bot/CHANGELOG.md
@@ -8,6 +8,21 @@ The version here always matches `manifest.json`'s `version`.
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-09-06
+
+### Changed
+
+- **A `regex` rule is now tested against the first 150 characters of a message, down from 1000.**
+  Backtracking cost grows with the input, so capping it bounds the worst case whatever the pattern
+  looks like. The parse-time screen accepts some polynomial shapes it cannot recognise in the pattern
+  text (`(a|b)*(a|b)*(a|b)*$`, `[ab]*[bc]*[cd]*$`, `\w*\d*\w*x`); measured against alternating input,
+  the worst of them runs past 8 s at 1000 characters, 2.8 s at 250, and 362 ms at 150. The host aborts
+  a hook at 5 s and cannot interrupt a running regex, so the cap is set to hold on a host several times
+  slower than the machine that measured it.
+  A regex rule therefore no longer matches text past the first 150 characters. `contains` and `exact`
+  cannot backtrack and are not capped, so they still see the whole message; `contains` is the right
+  mode for "mentions X anywhere in a long message".
+
 ## [0.2.9] - 2026-09-05
 
 ### Fixed

--- a/faq-bot/README.md
+++ b/faq-bot/README.md
@@ -14,8 +14,8 @@
 | Field | Value |
 | ----- | ----- |
 | **Identifier** | `faq-bot` |
-| **Version** | 0.2.9 |
-| **Released** | 2026-09-05 |
+| **Version** | 0.2.10 |
+| **Released** | 2026-09-06 |
 | **Status** | stable |
 | **Author** | Yudhi Armyndharis |
 | **License** | MIT |
@@ -109,21 +109,32 @@ rule sets.
 
 ## Security
 
-`regex` patterns are operator-authored (trusted) and tested against at most the first 1000 characters
-of a message. At parse time every pattern is screened for catastrophic-backtracking shapes — nested,
+Two controls, each covering what the other cannot.
+
+**The input cap.** A `regex` rule is tested against at most the first **150 characters** of a message.
+Backtracking cost grows with the input, so capping it sets the ceiling directly, whatever the pattern
+looks like. `contains` and `exact` cannot backtrack and are not capped, so they still see the whole
+message: use `contains` when you need "mentions X anywhere in a long message".
+
+**The parse-time screen.** Every pattern is checked for catastrophic-backtracking shapes: nested,
 adjacent-overlapping, and repeated-variable-width quantifiers (e.g. `(a+)+`, `.*.*.*`, `(a?){40}`), plus
-ambiguous repeated alternations (`(a|a)*`, `(a|ab)+`, `^([a-z]|[a-z0-9])+$`, `^(\w|\d)+$`) — and an
-unsafe one is skipped with a warning. This parse-time screen is the real safeguard: the sandbox hook
-timeout lets the host proceed but cannot interrupt a synchronous regex already running in the plugin
-worker, so a pattern that slips through would still pin that worker.
+ambiguous repeated alternations (`(a|a)*`, `(a|ab)+`, `^([a-z]|[a-z0-9])+$`, `^(\w|\d)+$`). An unsafe
+pattern is skipped with a warning.
+
+The split matters because the two failure modes are not alike. Exponential shapes stay fatal at any
+input length, so only the screen can stop them, and they are the ones it recognises reliably. Polynomial
+shapes are the opposite: hard to see in the pattern text, but bounded by the cap. The host aborts a hook
+at 5 s and cannot interrupt a regex already running, so the ceiling has to hold on a slow host too.
 
 An alternation is only rejected when two branches can consume the same text AND the repetition lands
 directly on it, including through a group that adds nothing but parentheses (`((a|a))+`). A wrapper that
 also contributes a mandatory atom is not that shape: the atom realigns every iteration, so ordinary
 keyword sets like `(one|two|three)+`, `^(ya|tidak)$` and `^((no|nope) )+$` are unaffected even where two
 branches share a first letter.
-The screen is a heuristic rather than a decision procedure: it covers the shapes that occur in real rule
-sets, and the 1000-character body cap remains as the second line of defence.
+The screen is a heuristic rather than a decision procedure, and it is known to accept some polynomial
+shapes: `(a|b)*(a|b)*(a|b)*$` and `[ab]*[bc]*[cd]*$` pass it. Those are safe because of the cap, not
+because the screen understood them. Measured on the worst of them against alternating input, 1000
+characters runs past 8 s while 150 takes 362 ms.
 
 The same inbound text is answered at most once every 10 seconds per chat. A rule whose reply also
 matches its own pattern is a fixed point, and an autoresponder on the other end would otherwise trade

--- a/faq-bot/manifest.json
+++ b/faq-bot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "faq-bot",
   "name": "FAQ / Auto-Reply Bot",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "extension",
   "main": "dist/index.js",
   "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",

--- a/faq-bot/rules.test.ts
+++ b/faq-bot/rules.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseRules, matchRule, isSafeRegexPattern } from './rules.ts';
+import { parseRules, matchRule, isSafeRegexPattern, MAX_REGEX_INPUT } from './rules.ts';
 
 const ok = JSON.stringify([
   { mode: 'contains', pattern: 'harga', reply: 'Harga mulai 100rb' },
@@ -181,6 +181,41 @@ test('parseRules keeps legitimate patterns (adjacent DISJOINT classes, separated
   const { rules, skipped } = parseRules(JSON.stringify(corpus));
   assert.deepEqual(skipped, []);
   assert.equal(rules.length, corpus.length);
+});
+
+test('a regex only sees the first MAX_REGEX_INPUT characters, which is what bounds a blow-up', () => {
+  // The input cap is the control for polynomial backtracking, so it has to be pinned. A pattern the
+  // structural screen accepts can still be quadratic or cubic, and the only thing keeping that under
+  // the host's 5 s hook budget is how much text it is handed. Measured on the worst shape that gets
+  // past the screen, `((a|b)*(a|b)*)(a|b)*$` against alternating input: 1000 characters runs past 8 s,
+  // 300 takes 5.8 s, 250 takes 2.8 s, 150 takes 362 ms.
+  const { rules } = parseRules(JSON.stringify([{ mode: 'regex', pattern: 'needle', reply: 'found' }]));
+  assert.ok(matchRule(rules, 'needle at the very start'), 'a match inside the window still works');
+  assert.equal(matchRule(rules, 'x'.repeat(200) + 'needle'), null, 'past the window a regex no longer matches');
+
+  // `contains` and `exact` cannot backtrack, so they are deliberately NOT capped: an operator who
+  // needs "mentions X anywhere in a long message" should use `contains`, and it keeps working.
+  const { rules: contains } = parseRules(JSON.stringify([{ mode: 'contains', pattern: 'needle', reply: 'found' }]));
+  assert.ok(matchRule(contains, 'x'.repeat(5000) + 'needle'), 'contains still sees the whole body');
+});
+
+test('the cap holds the shapes the structural screen lets through', () => {
+  // These are accepted by isSafeRegexPattern and are genuinely polynomial. They are safe only because
+  // of the cap, so this pins the two together: raising it without re-measuring fails here.
+  //
+  // The input has to be adversarial INSIDE the window. The cap slices from the front, so a failing
+  // tail appended to a long message is simply cut off and the regex matches cheaply. An attacker
+  // sends a message whose first MAX_REGEX_INPUT characters are the bad case, which is what this
+  // builds: alternating text filling the window exactly, ending in a character no branch accepts.
+  const adversarial = 'ab'.repeat(Math.ceil(MAX_REGEX_INPUT / 2)).slice(0, MAX_REGEX_INPUT - 1) + 'Z';
+  assert.equal(adversarial.length, MAX_REGEX_INPUT);
+  for (const pattern of ['((a|b)*(a|b)*)(a|b)*$', '(a|b)*(a|b)*(a|b)*$', '[ab]*[bc]*[cd]*$']) {
+    assert.equal(isSafeRegexPattern(pattern), true, `guard rail: the screen accepts ${pattern}`);
+    const { rules } = parseRules(JSON.stringify([{ mode: 'regex', pattern, reply: 'r' }]));
+    const started = Date.now();
+    matchRule(rules, adversarial + 'x'.repeat(5000));
+    assert.ok(Date.now() - started < 2000, `${pattern} must stay bounded by the cap`);
+  }
 });
 
 test('matchRule: contains is case-insensitive substring; no match returns null', () => {

--- a/faq-bot/rules.ts
+++ b/faq-bot/rules.ts
@@ -9,8 +9,26 @@ export interface CompiledRule extends Rule {
 }
 
 const MODES: RuleMode[] = ['contains', 'exact', 'regex'];
-/** Cap on the body length a regex is tested against (defence in depth, not the ReDoS control). */
-const MAX_REGEX_INPUT = 1000;
+/**
+ * Cap on the body length a regex is tested against, and the PRIMARY control for polynomial blow-up.
+ *
+ * The screen below reads the pattern text, which works for the exponential shapes it can recognise
+ * syntactically (a quantifier on a group that holds one, an ambiguous repeated alternation) but not
+ * for the polynomial ones, where cost depends on how many ways an input splits between adjacent
+ * quantifiers. Those are not reliably visible in the text, and repeated attempts to make them so each
+ * closed one family of patterns while opening another.
+ *
+ * Bounding the input instead needs no model at all. A polynomial blow-up costs about n^3, so the cap
+ * sets the ceiling directly. Measured on the worst shape that gets past the screen,
+ * `((a|b)*(a|b)*)(a|b)*$` against alternating input: 1000 characters runs past 8 s, 300 takes 5.8 s,
+ * 250 takes 2.8 s, and 150 takes 362 ms. 150 is chosen so the ceiling holds on a host several times
+ * slower than the machine that measured it, since the host aborts a hook at 5 s and a running regex
+ * cannot be interrupted before then.
+ *
+ * This only applies to `regex` rules. `contains` and `exact` cannot backtrack, so they still see the
+ * whole message, and `contains` remains the right mode for "does this message mention X anywhere".
+ */
+export const MAX_REGEX_INPUT = 150;
 /** Reject absurdly long patterns outright. */
 const MAX_PATTERN_LENGTH = 1000;
 
@@ -140,7 +158,7 @@ const REPEAT_THRESHOLD = 10;
  *  1. an unbounded quantifier on a group that itself contains one — `(a+)+`, `((a+))+`, `(\w+\s?)*`;
  *  2. THREE OR MORE adjacent unbounded quantifiers over overlapping atoms in one concatenation —
  *     `.*.*.*`, `\w*\w*\w*` (O(n^3)+); TWO adjacent (`.*.*`, `.*\d+`) is only O(n^2), safe under the
- *     1000-char input cap, so it is allowed; a mandatory atom or a group boundary breaks the chain;
+ *     input cap, so it is allowed; a mandatory atom or a group boundary breaks the chain;
  *  3. an unbounded or ≥REPEAT_THRESHOLD repeat of a group whose body has a variable-width quantifier —
  *     `(a?){40}`, `(a?)+` (exponential); a small bounded repeat of a VARIABLE body like `(ab?){2}` is
  *     allowed, but any repeat of an UNBOUNDED body is not — see (1).
@@ -234,7 +252,7 @@ export function isSafeRegexPattern(p: string): boolean {
       // A wrapper that DOES contribute an atom is deliberately not propagated through. The atom is
       // mandatory in every iteration, so it realigns the match and the branches can no longer split
       // the same text: `((no|nope) )+$`, `^((satu|dua|(tiga|empat)),)+$` and `((ok|oke)\s)+` are all
-      // linear (measured at 0.0 ms against the 1000-char input cap) and all of them are rules an
+      // linear (measured at 0.0 ms against a full-length input) and all of them are rules an
       // operator really writes. Rejecting those would silently stop an upgraded install from replying.
       const pureCover = !frame.sawAtom && frame.branches.length === 1;
       const ambiguous =

--- a/plugins.json
+++ b/plugins.json
@@ -695,7 +695,7 @@
   {
     "id": "faq-bot",
     "name": "FAQ / Auto-Reply Bot",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "type": "extension",
     "status": "stable",
     "description": "Auto-replies to inbound WhatsApp messages from configurable FAQ keyword/regex rules.",
@@ -711,11 +711,11 @@
     ],
     "minOpenWAVersion": "0.6.1",
     "testedOpenWAVersion": "0.23.4",
-    "releasedAt": "2026-09-05",
+    "releasedAt": "2026-09-06",
     "repoPath": "faq-bot",
     "repoUrl": "https://github.com/rmyndharis/OpenWA-plugins",
     "homepage": "https://github.com/rmyndharis/OpenWA-plugins/tree/main/faq-bot",
-    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.9/faq-bot.zip#sha256=6513c8f31023395c8c98c9c7410dc999ee06516ee88d22417d776d37bbed811e",
+    "download": "https://github.com/rmyndharis/OpenWA-plugins/releases/download/faq-bot-v0.2.10/faq-bot.zip#sha256=c26deddca78e36bb46ed6b55da55a44e07450be27f638225da5cbba3e20906df",
     "permissions": [
       "messages:send"
     ],


### PR DESCRIPTION
Closes #112.

The parse-time screen reads the pattern text. That works for the exponential shapes it can recognise syntactically, a quantifier on a group that holds one and an ambiguous repeated alternation, but not for the polynomial ones, where cost depends on how many ways an input splits between adjacent quantifiers. Those are not reliably visible in the text: three separate attempts to make them so each closed one family of patterns while opening another, and one of them shipped a regression that refused ordinary rules such as `.*(\d+).*`.

Bounding the input needs no model at all. A polynomial blow-up costs about n^3, so the cap sets the ceiling directly, whatever the pattern looks like and including shapes nobody has found yet.

## Measured

Worst shape that gets past the screen, `((a|b)*(a|b)*)(a|b)*$`, against alternating input that fails on the last character:

| Cap | This machine | At half this speed | At a fifth |
| --- | --- | --- | --- |
| 1000 | over 8 s | | |
| 300 | 5.8 s | 11.6 s | 28.9 s |
| 250 | 2.8 s | 5.7 s | 14.2 s |
| **150** | **362 ms** | **723 ms** | **1.8 s** |

The host aborts a hook at 5 s and cannot interrupt a running regex, so the ceiling has to hold on a host slower than the one that measured it. 250 does not.

A fuzz over 106 patterns the screen accepts found one still above 5 s at 1000 characters and none at 250, so the cap also covers what the screen misses beyond the eight known cases in #112.

## Why not a smarter screen

Five independent designs were implemented and measured against a differential gate, reported in #112. All five closed the known holes and all five opened new ones, in four separate families. The pattern across them is that a text-level model of backtracking cost is at its limit, not that the right rule had not been found.

The two controls now cover what each is actually good at. Exponential shapes stay fatal at any input length, so only the screen can stop them, and they are the ones it recognises reliably. Polynomial shapes are the opposite: hard to see in the text, bounded by the cap.

## Cost

A `regex` rule no longer matches text past the first 150 characters. That is a predictable limit, documented in the plugin README, rather than a rule that silently stops answering.

`contains` and `exact` cannot backtrack and are not capped, so they still see the whole message. `contains` remains the right mode for matching a mention anywhere in a long one.

## Verification

`npm run typecheck`, `npm test` (660 pass), `npm run catalog:check`, `npm run loader:check`.

Two new tests pin the cap and fail if it is raised, verified at 300 and at 1000. The second builds its input to be adversarial inside the window, since the cap slices from the front and a failing tail appended to a long message is simply cut off, which made an earlier version of that test pass at any cap.

faq-bot 0.2.10.
